### PR TITLE
Removed duplicated local definition of findRepoRoot

### DIFF
--- a/semconvgen/generator.go
+++ b/semconvgen/generator.go
@@ -406,34 +406,3 @@ func format(fn string) error {
 
 	return nil
 }
-
-// findRepoRoot retrieves the root of the repository containing the current working directory.
-// Beginning at the current working directory (dir), the algorithm checks if joining the ".git"
-// suffix, such as "dir.get", is a valid file. Otherwise, it will continue checking the dir's
-// parent directory until it reaches the repo root or returns an error if it cannot be found.
-func findRepoRoot() (string, error) {
-	start, err := os.Getwd()
-	if err != nil {
-		return "", err
-	}
-
-	dir := start
-	for {
-		_, err := os.Stat(filepath.Join(dir, ".git"))
-		if errors.Is(err, os.ErrNotExist) {
-			dir = filepath.Dir(dir)
-			// From https://golang.org/pkg/path/filepath/#Dir:
-			// The returned path does not end in a separator unless it is the root directory.
-			if strings.HasSuffix(dir, string(filepath.Separator)) {
-				return "", fmt.Errorf("unable to find git repository enclosing working dir %s", start)
-			}
-			continue
-		}
-
-		if err != nil {
-			return "", err
-		}
-
-		return dir, nil
-	}
-}


### PR DESCRIPTION
Seems like the function `findRepoRoot` was duplicated in the `semconvgen/generator.go` file and is unused in favor of the common `tools.FindRepoRoot` func.