### PR TITLE
Add crosslink to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ dbotconf/dbotconf
 issuegenerator/issuegenerator
 multimod/multimod
 semconvgen/semconvgen
+crosslink/crosslink


### PR DESCRIPTION
Adds crosslink to gitignore. Was missed in PR split. 