### PR TITLE
Change command config creation logic

### DIFF
--- a/crosslink/cmd/root.go
+++ b/crosslink/cmd/root.go
@@ -31,7 +31,8 @@ type commandConfig struct {
 	pruneCommand cobra.Command
 }
 
-func (c *commandConfig) buildCommands() {
+func newCommandConfig() *commandConfig {
+	c := new(commandConfig)
 	preRunSetup := func(cmd *cobra.Command, args []string) {
 		c.runConfig.ExcludedPaths = transformExclude(c.excludeFlags)
 
@@ -80,11 +81,12 @@ func (c *commandConfig) buildCommands() {
 		},
 	}
 	c.rootCommand.AddCommand(&c.pruneCommand)
-
+	c.runConfig = cl.DefaultRunConfig()
+	return c
 }
 
 var (
-	comCfg = new(commandConfig)
+	comCfg = newCommandConfig()
 )
 
 // Execute adds all child commands to the root command and sets flags appropriately.
@@ -98,7 +100,6 @@ func Execute() {
 }
 
 func init() {
-	comCfg.buildCommands()
 
 	comCfg.rootCommand.PersistentFlags().StringVar(&comCfg.runConfig.RootPath, "root", "", "path to root directory of multi-module repository")
 	comCfg.rootCommand.PersistentFlags().StringSliceVar(&comCfg.excludeFlags, "exclude", []string{}, "list of comma separated go modules that crosslink will ignore in operations."+

--- a/crosslink/cmd/root.go
+++ b/crosslink/cmd/root.go
@@ -32,7 +32,9 @@ type commandConfig struct {
 }
 
 func newCommandConfig() *commandConfig {
-	c := new(commandConfig)
+	c := &commandConfig{
+		runConfig: cl.DefaultRunConfig(),
+	}
 	preRunSetup := func(cmd *cobra.Command, args []string) {
 		c.runConfig.ExcludedPaths = transformExclude(c.excludeFlags)
 
@@ -81,7 +83,6 @@ func newCommandConfig() *commandConfig {
 		},
 	}
 	c.rootCommand.AddCommand(&c.pruneCommand)
-	c.runConfig = cl.DefaultRunConfig()
 	return c
 }
 


### PR DESCRIPTION
This PR changes how the command config is created to address a bug where `DefaultRunConfig` was never called. Command config creation is now bundled into `newCommandConfig` where commands are added and a run config is created. 