### PR TITLE
Set rootPath to cwd

### DIFF
--- a/crosslink/README.md
+++ b/crosslink/README.md
@@ -53,7 +53,7 @@ root flag is available to all crosslink subcommands.
 
 **Note: If no --root flag is provided than crosslink attempts to identify a git
 repository in the current or a parent directory. If no git repository exists
-crosslink will panic.**
+crosslink will return an error.**
 
     crosslink --root=/users/foo/multimodule-go-repo
 

--- a/crosslink/cmd/root.go
+++ b/crosslink/cmd/root.go
@@ -35,8 +35,17 @@ func newCommandConfig() *commandConfig {
 	c := &commandConfig{
 		runConfig: cl.DefaultRunConfig(),
 	}
+
 	preRunSetup := func(cmd *cobra.Command, args []string) {
 		c.runConfig.ExcludedPaths = transformExclude(c.excludeFlags)
+
+		if c.runConfig.RootPath == "" {
+			cwd, err := os.Getwd()
+			if err != nil {
+				log.Printf("Could not get current working directory: %e", err)
+			}
+			c.runConfig.RootPath = cwd
+		}
 
 		// enable verbosity on overwrite if user has not supplied another value
 		vExists := false

--- a/crosslink/cmd/root.go
+++ b/crosslink/cmd/root.go
@@ -15,11 +15,13 @@
 package cmd
 
 import (
+	"fmt"
 	"log"
 	"os"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
+	tools "go.opentelemetry.io/build-tools"
 	cl "go.opentelemetry.io/build-tools/crosslink/internal"
 	"go.uber.org/zap"
 )
@@ -36,15 +38,15 @@ func newCommandConfig() *commandConfig {
 		runConfig: cl.DefaultRunConfig(),
 	}
 
-	preRunSetup := func(cmd *cobra.Command, args []string) {
+	preRunSetup := func(cmd *cobra.Command, args []string) error {
 		c.runConfig.ExcludedPaths = transformExclude(c.excludeFlags)
 
 		if c.runConfig.RootPath == "" {
-			cwd, err := os.Getwd()
+			rp, err := tools.FindRepoRoot()
 			if err != nil {
-				log.Printf("Could not get current working directory: %e", err)
+				return fmt.Errorf("could not find a valid repository: %w", err)
 			}
-			c.runConfig.RootPath = cwd
+			c.runConfig.RootPath = rp
 		}
 
 		// enable verbosity on overwrite if user has not supplied another value
@@ -61,10 +63,10 @@ func newCommandConfig() *commandConfig {
 		if c.runConfig.Verbose {
 			c.runConfig.Logger, err = zap.NewDevelopment()
 			if err != nil {
-				log.Printf("Could not create zap logger: %v", err)
+				return fmt.Errorf("could not create zap logger: %w", err)
 			}
-
 		}
+		return nil
 
 	}
 
@@ -74,7 +76,7 @@ func newCommandConfig() *commandConfig {
 		Long: `Crosslink is a tool to assist with go.mod file management for repositories containing
 		mulitple go modules. Crosslink automatically inserts replace statements into go.mod files
 		for all intra-repository dependencies including transitive dependencies so the local module is used.`,
-		PersistentPreRun: preRunSetup,
+		PersistentPreRunE: preRunSetup,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return cl.Crosslink(c.runConfig)
 		},
@@ -111,7 +113,8 @@ func Execute() {
 
 func init() {
 
-	comCfg.rootCommand.PersistentFlags().StringVar(&comCfg.runConfig.RootPath, "root", "", "path to root directory of multi-module repository")
+	comCfg.rootCommand.PersistentFlags().StringVar(&comCfg.runConfig.RootPath, "root", "", `path to root directory of multi-module repository. If --root flag is not provided crosslink will attempt to find a
+	git repository in the current or a parent directory.`)
 	comCfg.rootCommand.PersistentFlags().StringSliceVar(&comCfg.excludeFlags, "exclude", []string{}, "list of comma separated go modules that crosslink will ignore in operations."+
 		"multiple calls of --exclude can be made")
 	comCfg.rootCommand.PersistentFlags().BoolVarP(&comCfg.runConfig.Verbose, "verbose", "v", false, "verbose output")

--- a/crosslink/cmd/root_test.go
+++ b/crosslink/cmd/root_test.go
@@ -14,6 +14,7 @@
 package cmd
 
 import (
+	"os"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -146,8 +147,13 @@ func TestPreRun(t *testing.T) {
 		t.Run(test.testName, func(t *testing.T) {
 			t.Cleanup(configReset)
 			comCfg.runConfig = test.mockConfig
+			cwd, err := os.Getwd()
+			if err != nil {
+				t.Errorf("%e", err)
+			}
+			test.expectedConfig.RootPath = cwd
 
-			err := comCfg.rootCommand.ParseFlags(test.args)
+			err = comCfg.rootCommand.ParseFlags(test.args)
 			if err != nil {
 				t.Errorf("Failed to parse flags: %v", err)
 			}

--- a/crosslink/cmd/root_test.go
+++ b/crosslink/cmd/root_test.go
@@ -160,7 +160,8 @@ func TestPreRun(t *testing.T) {
 			}
 
 			testPreRun := comCfg.rootCommand.PersistentPreRunE
-			testPreRun(&comCfg.rootCommand, nil)
+			err = testPreRun(&comCfg.rootCommand, nil)
+			assert.NoError(t, err, "Pre Run returned error")
 
 			if diff := cmp.Diff(test.expectedConfig, comCfg.runConfig, cmpopts.IgnoreFields(cl.RunConfig{}, "Logger", "ExcludedPaths")); diff != "" {
 				t.Errorf("TestCase: %s \n Replace{} mismatch (-want +got):\n%s", test.testName, diff)

--- a/crosslink/cmd/root_test.go
+++ b/crosslink/cmd/root_test.go
@@ -14,7 +14,7 @@
 package cmd
 
 import (
-	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -147,19 +147,19 @@ func TestPreRun(t *testing.T) {
 		t.Run(test.testName, func(t *testing.T) {
 			t.Cleanup(configReset)
 			comCfg.runConfig = test.mockConfig
-			cwd, err := os.Getwd()
-			if err != nil {
-				t.Errorf("%e", err)
-			}
-			test.expectedConfig.RootPath = cwd
 
+			expectedRootPath, err := filepath.Abs("../../")
+			if err != nil {
+				t.Errorf("could not parse expected root path: %e", err)
+			}
+
+			test.expectedConfig.RootPath = expectedRootPath
 			err = comCfg.rootCommand.ParseFlags(test.args)
 			if err != nil {
 				t.Errorf("Failed to parse flags: %v", err)
 			}
-			comCfg.rootCommand.DebugFlags()
 
-			testPreRun := comCfg.rootCommand.PersistentPreRun
+			testPreRun := comCfg.rootCommand.PersistentPreRunE
 			testPreRun(&comCfg.rootCommand, nil)
 
 			if diff := cmp.Diff(test.expectedConfig, comCfg.runConfig, cmpopts.IgnoreFields(cl.RunConfig{}, "Logger", "ExcludedPaths")); diff != "" {

--- a/crosslink/cmd/root_test.go
+++ b/crosslink/cmd/root_test.go
@@ -14,6 +14,8 @@
 package cmd
 
 import (
+	"fmt"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -21,6 +23,7 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/stretchr/testify/assert"
 	cl "go.opentelemetry.io/build-tools/crosslink/internal"
+	"go.uber.org/zap"
 )
 
 func TestTransform(t *testing.T) {
@@ -60,12 +63,21 @@ func TestTransform(t *testing.T) {
 	}
 }
 
+var configReset func() = func() {
+	comCfg.runConfig = cl.DefaultRunConfig()
+	comCfg.rootCommand.SetArgs([]string{})
+}
+
 // Validate run config is valid after pre run.
 func TestPreRun(t *testing.T) {
-	configReset := func() {
-		comCfg.runConfig = cl.DefaultRunConfig()
-		comCfg.rootCommand.SetArgs([]string{})
+
+	validRootPath, err := filepath.Abs("../../")
+	if err != nil {
+		t.Errorf("could not parse expected root path: %e", err)
 	}
+	validProdLogger, err := zap.NewProduction()
+	assert.NoError(t, err, "failed to create prod logger")
+
 	tests := []struct {
 		testName       string
 		args           []string
@@ -73,10 +85,15 @@ func TestPreRun(t *testing.T) {
 		expectedConfig cl.RunConfig
 	}{
 		{
-			testName:       "Default Config",
-			args:           []string{},
-			mockConfig:     cl.DefaultRunConfig(),
-			expectedConfig: cl.DefaultRunConfig(),
+			testName:   "Default Config",
+			args:       []string{},
+			mockConfig: cl.DefaultRunConfig(),
+			expectedConfig: cl.RunConfig{
+				Overwrite:     false,
+				RootPath:      validRootPath,
+				Logger:        validProdLogger,
+				ExcludedPaths: make(map[string]struct{}),
+			},
 		},
 		{
 			testName: "with overwrite",
@@ -86,6 +103,7 @@ func TestPreRun(t *testing.T) {
 			expectedConfig: cl.RunConfig{
 				Overwrite: true,
 				Verbose:   true,
+				RootPath:  validRootPath,
 			},
 			args: []string{"--overwrite"},
 		},
@@ -98,6 +116,7 @@ func TestPreRun(t *testing.T) {
 			expectedConfig: cl.RunConfig{
 				Overwrite: true,
 				Verbose:   false,
+				RootPath:  validRootPath,
 			},
 			args: []string{"--overwrite", "--verbose=false"},
 		},
@@ -107,7 +126,8 @@ func TestPreRun(t *testing.T) {
 				Prune: true,
 			},
 			expectedConfig: cl.RunConfig{
-				Prune: true,
+				Prune:    true,
+				RootPath: validRootPath,
 			},
 			args: []string{"--prune"},
 		},
@@ -117,7 +137,8 @@ func TestPreRun(t *testing.T) {
 				Prune: true,
 			},
 			expectedConfig: cl.RunConfig{
-				Prune: true,
+				Prune:    true,
+				RootPath: validRootPath,
 			},
 			args: []string{"-p"},
 		},
@@ -127,7 +148,8 @@ func TestPreRun(t *testing.T) {
 				Verbose: true,
 			},
 			expectedConfig: cl.RunConfig{
-				Verbose: true,
+				Verbose:  true,
+				RootPath: validRootPath,
 			},
 			args: []string{"--verbose"},
 		},
@@ -137,9 +159,19 @@ func TestPreRun(t *testing.T) {
 				Verbose: true,
 			},
 			expectedConfig: cl.RunConfig{
-				Verbose: true,
+				Verbose:  true,
+				RootPath: validRootPath,
 			},
 			args: []string{"-v"},
+		},
+		{
+			testName:   "with good root path",
+			mockConfig: cl.DefaultRunConfig(),
+			expectedConfig: cl.RunConfig{
+				RootPath: validRootPath,
+				Logger:   validProdLogger,
+			},
+			args: []string{fmt.Sprintf("--root=%s", validRootPath)},
 		},
 	}
 
@@ -148,13 +180,7 @@ func TestPreRun(t *testing.T) {
 			t.Cleanup(configReset)
 			comCfg.runConfig = test.mockConfig
 
-			expectedRootPath, err := filepath.Abs("../../")
-			if err != nil {
-				t.Errorf("could not parse expected root path: %e", err)
-			}
-
-			test.expectedConfig.RootPath = expectedRootPath
-			err = comCfg.rootCommand.ParseFlags(test.args)
+			err := comCfg.rootCommand.ParseFlags(test.args)
 			if err != nil {
 				t.Errorf("Failed to parse flags: %v", err)
 			}
@@ -164,8 +190,30 @@ func TestPreRun(t *testing.T) {
 			assert.NoError(t, err, "Pre Run returned error")
 
 			if diff := cmp.Diff(test.expectedConfig, comCfg.runConfig, cmpopts.IgnoreFields(cl.RunConfig{}, "Logger", "ExcludedPaths")); diff != "" {
-				t.Errorf("TestCase: %s \n Replace{} mismatch (-want +got):\n%s", test.testName, diff)
+				t.Errorf("TestCase: %s \n Config{} mismatch (-want +got):\n%s", test.testName, diff)
 			}
 		})
 	}
+}
+
+// isolated test because the working directory needs to changed
+// and it will keep the happy path test above clean
+func TestBadRootPath(t *testing.T) {
+	t.Cleanup(configReset)
+	mockConfig := cl.DefaultRunConfig()
+	args := []string{}
+
+	// under the assumption that this is not a nested git repository
+	err := os.Chdir("/../../..")
+	assert.NoError(t, err, "failed to change working directory")
+	comCfg.runConfig = mockConfig
+
+	err = comCfg.rootCommand.ParseFlags(args)
+	if err != nil {
+		t.Errorf("Failed to parse flags: %v", err)
+	}
+
+	testPreRun := comCfg.rootCommand.PersistentPreRunE
+	err = testPreRun(&comCfg.rootCommand, nil)
+	assert.Error(t, err, "Pre Run did not return error")
 }

--- a/crosslink/internal/common.go
+++ b/crosslink/internal/common.go
@@ -19,21 +19,13 @@ import (
 	"os"
 	"path/filepath"
 
-	tools "go.opentelemetry.io/build-tools"
 	"golang.org/x/mod/modfile"
 )
 
-// attempts to identify a go.mod file at the either the path provided
-// or at the root of the git repository. This check will fail if no path is
-// provided and the tool was called outside of a git repository.
+// Attempts to identify a go module at the root path. If no
+// go.mod file is present an error is returned.
 func identifyRootModule(rootPath string) (string, error) {
 	var err error
-	if rootPath == "" {
-		rootPath, err = tools.FindRepoRoot()
-		if err != nil {
-			return "", fmt.Errorf("failed find a valid .git repository: %w", err)
-		}
-	}
 
 	if _, err := os.Stat(filepath.Join(rootPath, "go.mod")); err != nil {
 		return "", fmt.Errorf("failed to identify go.mod file at root dir: %w", err)

--- a/crosslink/internal/crosslink_test.go
+++ b/crosslink/internal/crosslink_test.go
@@ -344,6 +344,8 @@ func TestExclude(t *testing.T) {
 				t.Errorf("error renaming gomod files: %v", err)
 			}
 
+			test.config.RootPath = tmpRootDir
+
 			err = Crosslink(test.config)
 
 			if assert.NoError(t, err, "error message on execution %s") {


### PR DESCRIPTION
This PR fixes an issue in crosslink where the default root path was not correctly set if the `--root` flag was not provided. The tests were also adjusted to account for this issue. 