### PR TITLE
add chloggen tool

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,17 @@
-# Code owners file.
-# This file controls who is tagged for review for any given pull request.
-
+#####################################################
+#
+# List of approvers for OpenTelemetry Build repository
+#
+#####################################################
+#
+# Learn about membership in OpenTelemetry community:
+#  https://github.com/open-telemetry/community/blob/master/community-membership.md
+#
+#
+# Learn about CODEOWNERS file format:
+#  https://help.github.com/en/articles/about-code-owners
+#
 # For anything not explicitly taken by someone else:
 * @open-telemetry/go-maintainers @open-telemetry/collector-maintainers
+
+chloggen/ @open-telemetry/collector-contrib-approvers @djaglowski @codeboten

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -29,6 +29,15 @@ updates:
       interval: weekly
       day: sunday
   - package-ecosystem: gomod
+    directory: /chloggen
+    labels:
+      - dependencies
+      - go
+      - Skip Changelog
+    schedule:
+      interval: weekly
+      day: sunday
+  - package-ecosystem: gomod
     directory: /crosslink
     labels:
       - dependencies

--- a/.github/workflows/markdown.yml
+++ b/.github/workflows/markdown.yml
@@ -31,7 +31,7 @@ jobs:
     - name: Run linter
       uses: docker://avtodev/markdown-lint:v1
       with:
-        args: ${{needs.changedfiles.outputs.md}}
+        args: -i "/**/testdata" ${{needs.changedfiles.outputs.md}}
 
   check-links:
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -9,8 +9,9 @@ Thumbs.db
 coverage.*
 
 checkdoc/checkdoc
+chloggen/chloggen
+crosslink/crosslink
 dbotconf/dbotconf
 issuegenerator/issuegenerator
 multimod/multimod
 semconvgen/semconvgen
-crosslink/crosslink

--- a/chloggen/README.md
+++ b/chloggen/README.md
@@ -1,0 +1,17 @@
+# Changelog generator
+
+Tool that can be used to generate a CHANGELOG file from individual change
+files written in YAML.
+
+Usage:
+
+```sh
+    # generates a new change YAML file from a template
+    chloggen new -filename <filename>
+    # validates all change YAML files
+    chloggen validate
+    # provide a preview of the generated changelog file
+    chloggen update -dry
+    # updates the changelog file
+    chloggen update -version <version>
+```

--- a/chloggen/context.go
+++ b/chloggen/context.go
@@ -1,0 +1,57 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+	"path/filepath"
+	"runtime"
+)
+
+const (
+	changelogMD   = "CHANGELOG.md"
+	unreleasedDir = "unreleased"
+	templateYAML  = "TEMPLATE.yaml"
+)
+
+// chlogContext enables tests by allowing them to work in an test directory
+type chlogContext struct {
+	changelogMD   string
+	unreleasedDir string
+	templateYAML  string
+}
+
+func newChlogContext(rootDir string) chlogContext {
+	return chlogContext{
+		changelogMD:   filepath.Join(rootDir, changelogMD),
+		unreleasedDir: filepath.Join(rootDir, unreleasedDir),
+		templateYAML:  filepath.Join(rootDir, unreleasedDir, templateYAML),
+	}
+}
+
+var defaultCtx = newChlogContext(repoRoot())
+
+func repoRoot() string {
+	return filepath.Dir(thisDir())
+}
+
+func thisDir() string {
+	_, filename, _, ok := runtime.Caller(0)
+	if !ok {
+		// This is not expected, but just in case
+		fmt.Println("FAIL: Could not determine module directory")
+	}
+	return filepath.Dir(filename)
+}

--- a/chloggen/entry.go
+++ b/chloggen/entry.go
@@ -1,0 +1,80 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+	"strings"
+)
+
+type Entry struct {
+	ChangeType string `yaml:"change_type"`
+	Component  string `yaml:"component"`
+	Note       string `yaml:"note"`
+	Issues     []int  `yaml:"issues"`
+	SubText    string `yaml:"subtext"`
+}
+
+var changeTypes = []string{
+	breaking,
+	deprecation,
+	newComponent,
+	enhancement,
+	bugFix,
+}
+
+func (e Entry) Validate() error {
+	var validType bool
+	for _, ct := range changeTypes {
+		if e.ChangeType == ct {
+			validType = true
+			break
+		}
+	}
+	if !validType {
+		return fmt.Errorf("'%s' is not a valid 'change_type'. Specify one of %v", e.ChangeType, changeTypes)
+	}
+
+	if e.Component == "" {
+		return fmt.Errorf("specify a 'component'")
+	}
+
+	if e.Note == "" {
+		return fmt.Errorf("specify a 'note'")
+	}
+
+	if len(e.Issues) == 0 {
+		return fmt.Errorf("specify one or more issues #'s")
+	}
+
+	return nil
+}
+
+func (e Entry) String() string {
+	issueStrs := make([]string, 0, len(e.Issues))
+	for _, issue := range e.Issues {
+		issueStrs = append(issueStrs, fmt.Sprintf("#%d", issue))
+	}
+	issueStr := strings.Join(issueStrs, ", ")
+
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("- `%s`: %s (%s)", e.Component, e.Note, issueStr))
+	if e.SubText != "" {
+		sb.WriteString("\n  ")
+		lines := strings.Split(strings.ReplaceAll(e.SubText, "\r\n", "\n"), "\n")
+		sb.WriteString(strings.Join(lines, "\n  "))
+	}
+	return sb.String()
+}

--- a/chloggen/go.mod
+++ b/chloggen/go.mod
@@ -1,0 +1,13 @@
+module github.com/open-telemetry/opentelemetry-collector-contrib/cmd/chloggen
+
+go 1.17
+
+require (
+	github.com/stretchr/testify v1.8.0
+	gopkg.in/yaml.v3 v3.0.1
+)
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+)

--- a/chloggen/go.sum
+++ b/chloggen/go.sum
@@ -1,0 +1,15 @@
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
+github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.8.0 h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PKk=
+github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/chloggen/main.go
+++ b/chloggen/main.go
@@ -1,0 +1,237 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"bytes"
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+const (
+	breaking     = "breaking"
+	deprecation  = "deprecation"
+	newComponent = "new_component"
+	enhancement  = "enhancement"
+	bugFix       = "bug_fix"
+
+	insertPoint = "<!-- next version -->\n"
+)
+
+func main() {
+	if len(os.Args) < 2 {
+		usage()
+		os.Exit(1)
+	}
+
+	newCmd := flag.NewFlagSet("new", flag.ExitOnError)
+	filename := newCmd.String("filename", "", "'filename' is required")
+
+	updateCmd := flag.NewFlagSet("preview", flag.ExitOnError)
+	version := updateCmd.String("version", "vTODO", "'version' will be rendered directly into the update text")
+	dry := updateCmd.Bool("dry", false, "'dry' will generate the update text and print to stdout")
+
+	switch command := os.Args[1]; command {
+	case "new":
+		if err := newCmd.Parse(os.Args[2:]); err != nil {
+			fmt.Printf("FAIL: new: %v\n", err)
+			os.Exit(1)
+		}
+		if err := initialize(defaultCtx, *filename); err != nil {
+			fmt.Printf("FAIL: new: %v\n", err)
+			os.Exit(1)
+		}
+	case "validate":
+		if err := validate(defaultCtx); err != nil {
+			fmt.Printf("FAIL: validate: %v\n", err)
+			os.Exit(1)
+		}
+	case "update":
+		if err := updateCmd.Parse(os.Args[2:]); err != nil {
+			fmt.Printf("FAIL: update: %v\n", err)
+			os.Exit(1)
+		}
+		if err := update(defaultCtx, *version, *dry); err != nil {
+			fmt.Printf("FAIL: update: %v\n", err)
+			os.Exit(1)
+		}
+	default:
+		usage()
+		os.Exit(1)
+	}
+}
+
+func initialize(ctx chlogContext, filename string) error {
+	path := filepath.Join(ctx.unreleasedDir, cleanFileName(filename))
+	var pathWithExt string
+	switch ext := filepath.Ext(path); ext {
+	case ".yaml":
+		pathWithExt = path
+	case ".yml":
+		pathWithExt = strings.TrimSuffix(path, ".yml") + ".yaml"
+	case "":
+		pathWithExt = path + ".yaml"
+	default:
+		return fmt.Errorf("non-yaml extension: %s", ext)
+	}
+
+	templateBytes, err := os.ReadFile(ctx.templateYAML)
+	if err != nil {
+		return err
+	}
+	err = os.WriteFile(pathWithExt, templateBytes, os.FileMode(0755))
+	if err != nil {
+		return err
+	}
+	fmt.Printf("Changelog entry template copied to: %s\n", pathWithExt)
+	return nil
+}
+
+func validate(ctx chlogContext) error {
+	if _, err := os.Stat(ctx.unreleasedDir); err != nil {
+		return err
+	}
+
+	entries, err := readEntries(ctx)
+	if err != nil {
+		return err
+	}
+	for _, entry := range entries {
+		if err = entry.Validate(); err != nil {
+			return err
+		}
+	}
+	fmt.Printf("PASS: all files in ./%s/ are valid\n", ctx.unreleasedDir)
+	return nil
+}
+
+func update(ctx chlogContext, version string, dry bool) error {
+	entries, err := readEntries(ctx)
+	if err != nil {
+		return err
+	}
+
+	if len(entries) == 0 {
+		return fmt.Errorf("no entries to add to the changelog")
+	}
+
+	chlogUpdate, err := generateSummary(version, entries)
+	if err != nil {
+		return err
+	}
+
+	if dry {
+		fmt.Printf("Generated changelog updates:")
+		fmt.Println(chlogUpdate)
+		return nil
+	}
+
+	oldChlogBytes, err := os.ReadFile(ctx.changelogMD)
+	if err != nil {
+		return err
+	}
+	chlogParts := bytes.Split(oldChlogBytes, []byte(insertPoint))
+	if len(chlogParts) != 2 {
+		return fmt.Errorf("expected one instance of %s", insertPoint)
+	}
+
+	chlogHeader, chlogHistory := string(chlogParts[0]), string(chlogParts[1])
+
+	var chlogBuilder strings.Builder
+	chlogBuilder.WriteString(chlogHeader)
+	chlogBuilder.WriteString(insertPoint)
+	chlogBuilder.WriteString(chlogUpdate)
+	chlogBuilder.WriteString(chlogHistory)
+
+	tmpMD := ctx.changelogMD + ".tmp"
+	tmpChlogFile, err := os.Create(tmpMD)
+	if err != nil {
+		return err
+	}
+	if _, err := tmpChlogFile.WriteString(chlogBuilder.String()); err != nil {
+		return err
+	}
+	if err := tmpChlogFile.Close(); err != nil {
+		return err
+	}
+
+	if err := os.Rename(tmpMD, ctx.changelogMD); err != nil {
+		return err
+	}
+
+	fmt.Printf("Finished updating %s\n", ctx.changelogMD)
+
+	return deleteEntries(ctx)
+}
+
+func readEntries(ctx chlogContext) ([]*Entry, error) {
+	entryYAMLs, err := filepath.Glob(filepath.Join(ctx.unreleasedDir, "*.yaml"))
+	if err != nil {
+		return nil, err
+	}
+
+	entries := make([]*Entry, 0, len(entryYAMLs))
+	for _, entryYAML := range entryYAMLs {
+		if filepath.Base(entryYAML) == filepath.Base(ctx.templateYAML) {
+			continue
+		}
+
+		fileBytes, err := os.ReadFile(entryYAML)
+		if err != nil {
+			return nil, err
+		}
+
+		entry := &Entry{}
+		if err = yaml.Unmarshal(fileBytes, entry); err != nil {
+			return nil, err
+		}
+		entries = append(entries, entry)
+	}
+	return entries, nil
+}
+
+func deleteEntries(ctx chlogContext) error {
+	entryYAMLs, err := filepath.Glob(filepath.Join(ctx.unreleasedDir, "*.yaml"))
+	if err != nil {
+		return err
+	}
+
+	for _, entryYAML := range entryYAMLs {
+		if filepath.Base(entryYAML) == filepath.Base(ctx.templateYAML) {
+			continue
+		}
+
+		if err := os.Remove(entryYAML); err != nil {
+			fmt.Printf("Failed to delete: %s\n", entryYAML)
+		}
+	}
+	return nil
+}
+
+func cleanFileName(filename string) string {
+	replace := strings.NewReplacer("/", "_", "\\", "_")
+	return replace.Replace(filename)
+}
+
+func usage() {
+	fmt.Println("usage: [FILENAME=my-change] chloggen new")
+	fmt.Println("       chloggen validate")
+	fmt.Println("       chloggen update [-version v0.55.0] [-dry]")
+}

--- a/chloggen/main_test.go
+++ b/chloggen/main_test.go
@@ -1,0 +1,344 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+func TestNew(t *testing.T) {
+	tests := []struct {
+		name     string
+		filename string
+		wantErr  string
+	}{
+		{
+			name:     "no_extension",
+			filename: "my-change",
+		},
+		{
+			name:     "yaml_extension",
+			filename: "some-change.yaml",
+		},
+		{
+			name:     "yml_extension",
+			filename: "some-change.yml",
+		},
+		{
+			name:     "replace_forward_slash",
+			filename: "replace/forward/slash",
+		},
+		{
+			name:     "bad_extension",
+			filename: "my-change.txt",
+			wantErr:  "non-yaml extension",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := setupTestDir(t, []*Entry{})
+			err := initialize(ctx, tc.filename)
+			if tc.wantErr != "" {
+				require.Regexp(t, tc.wantErr, err)
+				return
+			}
+			require.NoError(t, err)
+
+			require.Error(t, validate(ctx), "The new entry should not be valid without user input")
+		})
+	}
+}
+
+func TestValidateE2E(t *testing.T) {
+	tests := []struct {
+		name    string
+		entries []*Entry
+		wantErr string
+	}{
+		{
+			name:    "all_valid",
+			entries: getSampleEntries(),
+		},
+		{
+			name: "invalid_change_type",
+			entries: func() []*Entry {
+				return append(getSampleEntries(), &Entry{
+					ChangeType: "fake",
+					Component:  "receiver/foo",
+					Note:       "Add some bar",
+					Issues:     []int{12345},
+				})
+			}(),
+			wantErr: "'fake' is not a valid 'change_type'",
+		},
+		{
+			name: "missing_component",
+			entries: func() []*Entry {
+				return append(getSampleEntries(), &Entry{
+					ChangeType: bugFix,
+					Component:  "",
+					Note:       "Add some bar",
+					Issues:     []int{12345},
+				})
+			}(),
+			wantErr: "specify a 'component'",
+		},
+		{
+			name: "missing_note",
+			entries: func() []*Entry {
+				return append(getSampleEntries(), &Entry{
+					ChangeType: bugFix,
+					Component:  "receiver/foo",
+					Note:       "",
+					Issues:     []int{12345},
+				})
+			}(),
+			wantErr: "specify a 'note'",
+		},
+		{
+			name: "missing_issue",
+			entries: func() []*Entry {
+				return append(getSampleEntries(), &Entry{
+					ChangeType: bugFix,
+					Component:  "receiver/foo",
+					Note:       "Add some bar",
+					Issues:     []int{},
+				})
+			}(),
+			wantErr: "specify one or more issues #'s",
+		},
+		{
+			name: "all_invalid",
+			entries: func() []*Entry {
+				sampleEntries := getSampleEntries()
+				for _, e := range sampleEntries {
+					e.ChangeType = "fake"
+				}
+				return sampleEntries
+			}(),
+			wantErr: "'fake' is not a valid 'change_type'",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := setupTestDir(t, tc.entries)
+
+			err := validate(ctx)
+			if tc.wantErr != "" {
+				require.Regexp(t, tc.wantErr, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestUpdateE2E(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Windows line breaks cause comparison failures w/ golden files.")
+	}
+	tests := []struct {
+		name    string
+		entries []*Entry
+		version string
+		dry     bool
+	}{
+		{
+			name:    "all_change_types",
+			entries: getSampleEntries(),
+			version: "v0.45.0",
+		},
+		{
+			name:    "all_change_types_multiple",
+			entries: append(getSampleEntries(), getSampleEntries()...),
+			version: "v0.45.0",
+		},
+		{
+			name:    "dry_run",
+			entries: getSampleEntries(),
+			version: "v0.45.0",
+			dry:     true,
+		},
+		{
+			name:    "deprecation_only",
+			entries: []*Entry{deprecationEntry()},
+			version: "v0.45.0",
+		},
+		{
+			name:    "new_component_only",
+			entries: []*Entry{newComponentEntry()},
+			version: "v0.45.0",
+		},
+		{
+			name:    "bug_fix_only",
+			entries: []*Entry{bugFixEntry()},
+			version: "v0.45.0",
+		},
+		{
+			name:    "enhancement_only",
+			entries: []*Entry{enhancementEntry()},
+			version: "v0.45.0",
+		},
+		{
+			name:    "breaking_only",
+			entries: []*Entry{breakingEntry()},
+			version: "v0.45.0",
+		},
+		{
+			name:    "subtext",
+			entries: []*Entry{entryWithSubtext()},
+			version: "v0.45.0",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := setupTestDir(t, tc.entries)
+
+			require.NoError(t, update(ctx, tc.version, tc.dry))
+
+			actualBytes, err := os.ReadFile(ctx.changelogMD)
+			require.NoError(t, err)
+
+			expectedChangelogMD := filepath.Join("testdata", tc.name+".md")
+			expectedBytes, err := os.ReadFile(expectedChangelogMD)
+			require.NoError(t, err)
+
+			require.Equal(t, string(expectedBytes), string(actualBytes))
+
+			remainingYAMLs, err := filepath.Glob(filepath.Join(ctx.unreleasedDir, "*.yaml"))
+			require.NoError(t, err)
+			if tc.dry {
+				require.Equal(t, 1+len(tc.entries), len(remainingYAMLs))
+			} else {
+				require.Equal(t, 1, len(remainingYAMLs))
+				require.Equal(t, ctx.templateYAML, remainingYAMLs[0])
+			}
+		})
+	}
+}
+
+func getSampleEntries() []*Entry {
+	return []*Entry{
+		enhancementEntry(),
+		bugFixEntry(),
+		deprecationEntry(),
+		newComponentEntry(),
+		breakingEntry(),
+		entryWithSubtext(),
+	}
+}
+
+func enhancementEntry() *Entry {
+	return &Entry{
+		ChangeType: enhancement,
+		Component:  "receiver/foo",
+		Note:       "Add some bar",
+		Issues:     []int{12345},
+	}
+}
+
+func bugFixEntry() *Entry {
+	return &Entry{
+		ChangeType: bugFix,
+		Component:  "testbed",
+		Note:       "Fix blah",
+		Issues:     []int{12346, 12347},
+	}
+}
+
+func deprecationEntry() *Entry {
+	return &Entry{
+		ChangeType: deprecation,
+		Component:  "exporter/old",
+		Note:       "Deprecate old",
+		Issues:     []int{12348},
+	}
+}
+
+func newComponentEntry() *Entry {
+	return &Entry{
+		ChangeType: newComponent,
+		Component:  "exporter/new",
+		Note:       "Add new exporter ...",
+		Issues:     []int{12349},
+	}
+}
+
+func breakingEntry() *Entry {
+	return &Entry{
+		ChangeType: breaking,
+		Component:  "processor/oops",
+		Note:       "Change behavior when ...",
+		Issues:     []int{12350},
+	}
+}
+
+func entryWithSubtext() *Entry {
+	lines := []string{"- foo\n  - bar\n- blah\n  - 1234567"}
+
+	return &Entry{
+		ChangeType: breaking,
+		Component:  "processor/oops",
+		Note:       "Change behavior when ...",
+		Issues:     []int{12350},
+		SubText:    strings.Join(lines, "\n"),
+	}
+}
+
+func setupTestDir(t *testing.T, entries []*Entry) chlogContext {
+	ctx := newChlogContext(t.TempDir())
+
+	// Create a known dummy changelog which may be updated by the test
+	changelogBytes, err := os.ReadFile(filepath.Join("testdata", changelogMD))
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(ctx.changelogMD, changelogBytes, os.FileMode(0755)))
+
+	require.NoError(t, os.Mkdir(ctx.unreleasedDir, os.FileMode(0755)))
+
+	// Copy the entry template, for tests that ensure it is not deleted
+	templateInRootDir := newChlogContext("testdata").templateYAML
+	templateBytes, err := os.ReadFile(templateInRootDir)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(ctx.templateYAML, templateBytes, os.FileMode(0755)))
+
+	for i, entry := range entries {
+		require.NoError(t, writeEntryYAML(ctx, fmt.Sprintf("%d.yaml", i), entry))
+	}
+
+	return ctx
+}
+
+func writeEntryYAML(ctx chlogContext, filename string, entry *Entry) error {
+	entryBytes, err := yaml.Marshal(entry)
+	if err != nil {
+		return err
+	}
+	path := filepath.Join(ctx.unreleasedDir, filename)
+	return os.WriteFile(path, entryBytes, os.FileMode(0755))
+}
+
+func TestCleanFilename(t *testing.T) {
+	require.Equal(t, "fix_some_bug", cleanFileName("fix/some_bug"))
+	require.Equal(t, "fix_some_bug", cleanFileName("fix\\some_bug"))
+}

--- a/chloggen/summary.go
+++ b/chloggen/summary.go
@@ -1,0 +1,78 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"path/filepath"
+	"sort"
+	"text/template"
+)
+
+type summary struct {
+	Version         string
+	BreakingChanges []string
+	Deprecations    []string
+	NewComponents   []string
+	Enhancements    []string
+	BugFixes        []string
+}
+
+func generateSummary(version string, entries []*Entry) (string, error) {
+	s := summary{
+		Version: version,
+	}
+
+	for _, entry := range entries {
+		switch entry.ChangeType {
+		case breaking:
+			s.BreakingChanges = append(s.BreakingChanges, entry.String())
+		case deprecation:
+			s.Deprecations = append(s.Deprecations, entry.String())
+		case newComponent:
+			s.NewComponents = append(s.NewComponents, entry.String())
+		case enhancement:
+			s.Enhancements = append(s.Enhancements, entry.String())
+		case bugFix:
+			s.BugFixes = append(s.BugFixes, entry.String())
+		}
+	}
+
+	s.BreakingChanges = sort.StringSlice(s.BreakingChanges)
+	s.Deprecations = sort.StringSlice(s.Deprecations)
+	s.NewComponents = sort.StringSlice(s.NewComponents)
+	s.Enhancements = sort.StringSlice(s.Enhancements)
+	s.BugFixes = sort.StringSlice(s.BugFixes)
+
+	return s.String()
+}
+
+func (s summary) String() (string, error) {
+	summaryTmpl := filepath.Join(thisDir(), "summary.tmpl")
+
+	tmpl := template.Must(
+		template.
+			New("summary.tmpl").
+			Option("missingkey=error").
+			ParseFiles(summaryTmpl))
+
+	buf := bytes.Buffer{}
+	if err := tmpl.Execute(&buf, s); err != nil {
+		return "", fmt.Errorf("failed executing template: %w", err)
+	}
+
+	return buf.String(), nil
+}

--- a/chloggen/summary.tmpl
+++ b/chloggen/summary.tmpl
@@ -1,0 +1,57 @@
+
+## {{ .Version }}
+
+{{- if .BreakingChanges }}
+
+### 🛑 Breaking changes 🛑
+
+{{- range $i, $change := .BreakingChanges }}
+{{- if eq $i 0}}
+{{end}}
+{{ $change }}
+{{- end }}
+{{- end }}
+
+{{- if .Deprecations }}
+
+### 🚩 Deprecations 🚩
+
+{{- range $i, $change := .Deprecations }}
+{{- if eq $i 0}}
+{{end}}
+{{ $change }}
+{{- end }}
+{{- end }}
+
+{{- if .NewComponents }}
+
+### 🚀 New components 🚀
+
+{{- range $i, $change := .NewComponents }}
+{{- if eq $i 0}}
+{{end}}
+{{ $change }}
+{{- end }}
+{{- end }}
+
+{{- if .Enhancements }}
+
+### 💡 Enhancements 💡
+
+{{- range $i, $change := .Enhancements }}
+{{- if eq $i 0}}
+{{end}}
+{{ $change }}
+{{- end }}
+{{- end }}
+
+{{- if .BugFixes }}
+
+### 🧰 Bug fixes 🧰
+
+{{- range $i, $change := .BugFixes }}
+{{- if eq $i 0}}
+{{end}}
+{{ $change }}
+{{- end }}
+{{- end }}

--- a/chloggen/testdata/CHANGELOG.md
+++ b/chloggen/testdata/CHANGELOG.md
@@ -1,0 +1,18 @@
+# Changelog
+
+<!-- next version -->
+
+## v0.44.0
+
+### 🛑 Breaking changes 🛑
+
+- `prometheusexporter`: Automatically rename metrics with units to follow Prometheus naming convention (#8950)
+
+### 💡 Enhancements 💡
+
+- `filterprocessor`: Ability to filter `Spans` (#6341)
+- `flinkmetricsreceiver`: add attribute values to metadata #11520
+
+### 🧰 Bug fixes 🧰
+
+- `redactionprocessor`: respect allow_all_keys configuration (#11542)

--- a/chloggen/testdata/all_change_types.md
+++ b/chloggen/testdata/all_change_types.md
@@ -1,0 +1,45 @@
+# Changelog
+
+<!-- next version -->
+
+## v0.45.0
+
+### 🛑 Breaking changes 🛑
+
+- `processor/oops`: Change behavior when ... (#12350)
+- `processor/oops`: Change behavior when ... (#12350)
+  - foo
+    - bar
+  - blah
+    - 1234567
+
+### 🚩 Deprecations 🚩
+
+- `exporter/old`: Deprecate old (#12348)
+
+### 🚀 New components 🚀
+
+- `exporter/new`: Add new exporter ... (#12349)
+
+### 💡 Enhancements 💡
+
+- `receiver/foo`: Add some bar (#12345)
+
+### 🧰 Bug fixes 🧰
+
+- `testbed`: Fix blah (#12346, #12347)
+
+## v0.44.0
+
+### 🛑 Breaking changes 🛑
+
+- `prometheusexporter`: Automatically rename metrics with units to follow Prometheus naming convention (#8950)
+
+### 💡 Enhancements 💡
+
+- `filterprocessor`: Ability to filter `Spans` (#6341)
+- `flinkmetricsreceiver`: add attribute values to metadata #11520
+
+### 🧰 Bug fixes 🧰
+
+- `redactionprocessor`: respect allow_all_keys configuration (#11542)

--- a/chloggen/testdata/all_change_types_multiple.md
+++ b/chloggen/testdata/all_change_types_multiple.md
@@ -1,0 +1,55 @@
+# Changelog
+
+<!-- next version -->
+
+## v0.45.0
+
+### 🛑 Breaking changes 🛑
+
+- `processor/oops`: Change behavior when ... (#12350)
+- `processor/oops`: Change behavior when ... (#12350)
+  - foo
+    - bar
+  - blah
+    - 1234567
+- `processor/oops`: Change behavior when ... (#12350)
+- `processor/oops`: Change behavior when ... (#12350)
+  - foo
+    - bar
+  - blah
+    - 1234567
+
+### 🚩 Deprecations 🚩
+
+- `exporter/old`: Deprecate old (#12348)
+- `exporter/old`: Deprecate old (#12348)
+
+### 🚀 New components 🚀
+
+- `exporter/new`: Add new exporter ... (#12349)
+- `exporter/new`: Add new exporter ... (#12349)
+
+### 💡 Enhancements 💡
+
+- `receiver/foo`: Add some bar (#12345)
+- `receiver/foo`: Add some bar (#12345)
+
+### 🧰 Bug fixes 🧰
+
+- `testbed`: Fix blah (#12346, #12347)
+- `testbed`: Fix blah (#12346, #12347)
+
+## v0.44.0
+
+### 🛑 Breaking changes 🛑
+
+- `prometheusexporter`: Automatically rename metrics with units to follow Prometheus naming convention (#8950)
+
+### 💡 Enhancements 💡
+
+- `filterprocessor`: Ability to filter `Spans` (#6341)
+- `flinkmetricsreceiver`: add attribute values to metadata #11520
+
+### 🧰 Bug fixes 🧰
+
+- `redactionprocessor`: respect allow_all_keys configuration (#11542)

--- a/chloggen/testdata/breaking_only.md
+++ b/chloggen/testdata/breaking_only.md
@@ -1,0 +1,24 @@
+# Changelog
+
+<!-- next version -->
+
+## v0.45.0
+
+### 🛑 Breaking changes 🛑
+
+- `processor/oops`: Change behavior when ... (#12350)
+
+## v0.44.0
+
+### 🛑 Breaking changes 🛑
+
+- `prometheusexporter`: Automatically rename metrics with units to follow Prometheus naming convention (#8950)
+
+### 💡 Enhancements 💡
+
+- `filterprocessor`: Ability to filter `Spans` (#6341)
+- `flinkmetricsreceiver`: add attribute values to metadata #11520
+
+### 🧰 Bug fixes 🧰
+
+- `redactionprocessor`: respect allow_all_keys configuration (#11542)

--- a/chloggen/testdata/bug_fix_only.md
+++ b/chloggen/testdata/bug_fix_only.md
@@ -1,0 +1,24 @@
+# Changelog
+
+<!-- next version -->
+
+## v0.45.0
+
+### 🧰 Bug fixes 🧰
+
+- `testbed`: Fix blah (#12346, #12347)
+
+## v0.44.0
+
+### 🛑 Breaking changes 🛑
+
+- `prometheusexporter`: Automatically rename metrics with units to follow Prometheus naming convention (#8950)
+
+### 💡 Enhancements 💡
+
+- `filterprocessor`: Ability to filter `Spans` (#6341)
+- `flinkmetricsreceiver`: add attribute values to metadata #11520
+
+### 🧰 Bug fixes 🧰
+
+- `redactionprocessor`: respect allow_all_keys configuration (#11542)

--- a/chloggen/testdata/deprecation_only.md
+++ b/chloggen/testdata/deprecation_only.md
@@ -1,0 +1,24 @@
+# Changelog
+
+<!-- next version -->
+
+## v0.45.0
+
+### 🚩 Deprecations 🚩
+
+- `exporter/old`: Deprecate old (#12348)
+
+## v0.44.0
+
+### 🛑 Breaking changes 🛑
+
+- `prometheusexporter`: Automatically rename metrics with units to follow Prometheus naming convention (#8950)
+
+### 💡 Enhancements 💡
+
+- `filterprocessor`: Ability to filter `Spans` (#6341)
+- `flinkmetricsreceiver`: add attribute values to metadata #11520
+
+### 🧰 Bug fixes 🧰
+
+- `redactionprocessor`: respect allow_all_keys configuration (#11542)

--- a/chloggen/testdata/dry_run.md
+++ b/chloggen/testdata/dry_run.md
@@ -1,0 +1,18 @@
+# Changelog
+
+<!-- next version -->
+
+## v0.44.0
+
+### 🛑 Breaking changes 🛑
+
+- `prometheusexporter`: Automatically rename metrics with units to follow Prometheus naming convention (#8950)
+
+### 💡 Enhancements 💡
+
+- `filterprocessor`: Ability to filter `Spans` (#6341)
+- `flinkmetricsreceiver`: add attribute values to metadata #11520
+
+### 🧰 Bug fixes 🧰
+
+- `redactionprocessor`: respect allow_all_keys configuration (#11542)

--- a/chloggen/testdata/enhancement_only.md
+++ b/chloggen/testdata/enhancement_only.md
@@ -1,0 +1,24 @@
+# Changelog
+
+<!-- next version -->
+
+## v0.45.0
+
+### 💡 Enhancements 💡
+
+- `receiver/foo`: Add some bar (#12345)
+
+## v0.44.0
+
+### 🛑 Breaking changes 🛑
+
+- `prometheusexporter`: Automatically rename metrics with units to follow Prometheus naming convention (#8950)
+
+### 💡 Enhancements 💡
+
+- `filterprocessor`: Ability to filter `Spans` (#6341)
+- `flinkmetricsreceiver`: add attribute values to metadata #11520
+
+### 🧰 Bug fixes 🧰
+
+- `redactionprocessor`: respect allow_all_keys configuration (#11542)

--- a/chloggen/testdata/new_component_only.md
+++ b/chloggen/testdata/new_component_only.md
@@ -1,0 +1,24 @@
+# Changelog
+
+<!-- next version -->
+
+## v0.45.0
+
+### 🚀 New components 🚀
+
+- `exporter/new`: Add new exporter ... (#12349)
+
+## v0.44.0
+
+### 🛑 Breaking changes 🛑
+
+- `prometheusexporter`: Automatically rename metrics with units to follow Prometheus naming convention (#8950)
+
+### 💡 Enhancements 💡
+
+- `filterprocessor`: Ability to filter `Spans` (#6341)
+- `flinkmetricsreceiver`: add attribute values to metadata #11520
+
+### 🧰 Bug fixes 🧰
+
+- `redactionprocessor`: respect allow_all_keys configuration (#11542)

--- a/chloggen/testdata/subtext.md
+++ b/chloggen/testdata/subtext.md
@@ -1,0 +1,28 @@
+# Changelog
+
+<!-- next version -->
+
+## v0.45.0
+
+### 🛑 Breaking changes 🛑
+
+- `processor/oops`: Change behavior when ... (#12350)
+  - foo
+    - bar
+  - blah
+    - 1234567
+
+## v0.44.0
+
+### 🛑 Breaking changes 🛑
+
+- `prometheusexporter`: Automatically rename metrics with units to follow Prometheus naming convention (#8950)
+
+### 💡 Enhancements 💡
+
+- `filterprocessor`: Ability to filter `Spans` (#6341)
+- `flinkmetricsreceiver`: add attribute values to metadata #11520
+
+### 🧰 Bug fixes 🧰
+
+- `redactionprocessor`: respect allow_all_keys configuration (#11542)

--- a/chloggen/testdata/unreleased/TEMPLATE.yaml
+++ b/chloggen/testdata/unreleased/TEMPLATE.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type:
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component:
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note:
+
+# One or more tracking issues related to the change
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:


### PR DESCRIPTION
This tool is used in the OpenTelemetry collector repositories to generate the changelog from a set of YAML files. The reason for moving this tool here is to make it available for both collector and collector contrib repos.