### PR TITLE
[chloggen] use current directory as repo root

### DIFF
--- a/chloggen/context.go
+++ b/chloggen/context.go
@@ -16,6 +16,7 @@ package main
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 	"runtime"
 )
@@ -44,10 +45,15 @@ func newChlogContext(rootDir string) chlogContext {
 var defaultCtx = newChlogContext(repoRoot())
 
 func repoRoot() string {
-	return filepath.Dir(thisDir())
+	dir, err := os.Getwd()
+	if err != nil {
+		// This is not expected, but just in case
+		fmt.Println("FAIL: Could not determine current working directory")
+	}
+	return dir
 }
 
-func thisDir() string {
+func moduleDir() string {
 	_, filename, _, ok := runtime.Caller(0)
 	if !ok {
 		// This is not expected, but just in case

--- a/chloggen/main.go
+++ b/chloggen/main.go
@@ -54,6 +54,9 @@ func main() {
 			fmt.Printf("FAIL: new: %v\n", err)
 			os.Exit(1)
 		}
+		if len(*filename) == 0 {
+			fmt.Printf("FAIL: new: 'filename' is required\n")
+		}
 		if err := initialize(defaultCtx, *filename); err != nil {
 			fmt.Printf("FAIL: new: %v\n", err)
 			os.Exit(1)
@@ -118,7 +121,7 @@ func validate(ctx chlogContext) error {
 			return err
 		}
 	}
-	fmt.Printf("PASS: all files in ./%s/ are valid\n", ctx.unreleasedDir)
+	fmt.Printf("PASS: all files in %s/ are valid\n", ctx.unreleasedDir)
 	return nil
 }
 

--- a/chloggen/summary.go
+++ b/chloggen/summary.go
@@ -61,7 +61,7 @@ func generateSummary(version string, entries []*Entry) (string, error) {
 }
 
 func (s summary) String() (string, error) {
-	summaryTmpl := filepath.Join(thisDir(), "summary.tmpl")
+	summaryTmpl := filepath.Join(moduleDir(), "summary.tmpl")
 
 	tmpl := template.Must(
 		template.


### PR DESCRIPTION
This change allows chloggen to find the `unreleased` folder in the current directory, rather than expecting it to be in the module's directory. Also added a validation check for the filename on `new` command.