### PR TITLE
Update codeowners for chloggen

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -12,6 +12,7 @@
 #  https://help.github.com/en/articles/about-code-owners
 #
 # For anything not explicitly taken by someone else:
+
 * @open-telemetry/go-maintainers @open-telemetry/collector-maintainers
 
-chloggen/ @open-telemetry/collector-contrib-approvers @djaglowski @codeboten
+chloggen/ @open-telemetry/go-maintainers @open-telemetry/collector-maintainers @open-telemetry/collector-contrib-approvers


### PR DESCRIPTION
- Remove @djaglowski @codeboten they are part of @open-telemetry/collector-contrib-approvers
- Add @open-telemetry/go-maintainers @open-telemetry/collector-maintainers as owners as well, since we want the maintainers to be able to approve PRs like https://github.com/open-telemetry/opentelemetry-go-build-tools/pull/135

Signed-off-by: Bogdan Drutu <bogdandrutu@gmail.com>