### PR TITLE
[crosslink] Ignore known zap.logger.sync() errors

### DIFF
--- a/.chloggen/crosslinkErrSup.yaml
+++ b/.chloggen/crosslinkErrSup.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. crosslink)
+component: crosslink
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Ignore ENOTTY error produced by zaps logger.sync() method
+
+# One or more tracking issues related to the change
+issues: [190]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/.chloggen/crosslinkErrSup.yaml
+++ b/.chloggen/crosslinkErrSup.yaml
@@ -5,7 +5,8 @@ change_type: enhancement
 component: crosslink
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: Ignore ENOTTY error produced by zaps logger.sync() method
+note: Add internal build tools syncerror package to ignore known zap.logger.Sync() errors. 
+  Ignore known sync errors in crosslink.
 
 # One or more tracking issues related to the change
 issues: [190]

--- a/crosslink/cmd/root.go
+++ b/crosslink/cmd/root.go
@@ -15,11 +15,9 @@
 package cmd
 
 import (
-	"errors"
 	"fmt"
 	"log"
 	"os"
-	"syscall"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -27,6 +25,7 @@ import (
 
 	cl "go.opentelemetry.io/build-tools/crosslink/internal"
 	"go.opentelemetry.io/build-tools/internal/repo"
+	"go.opentelemetry.io/build-tools/internal/syncerror"
 )
 
 type commandConfig struct {
@@ -75,8 +74,8 @@ func newCommandConfig() *commandConfig {
 
 	postRunSetup := func(cmd *cobra.Command, args []string) error {
 		err := c.runConfig.Logger.Sync()
-		if err != nil && !errors.Is(err, syscall.ENOTTY) {
-			return fmt.Errorf("failed to sync logger: %w \n", err)
+		if err != nil && !syncerror.KnownSyncError(err) {
+			return fmt.Errorf("failed to sync logger: %w", err)
 		}
 		return nil
 	}

--- a/crosslink/internal/crosslink.go
+++ b/crosslink/internal/crosslink.go
@@ -57,10 +57,6 @@ func Crosslink(rc RunConfig) error {
 				zap.Error(err))
 		}
 	}
-	err = rc.Logger.Sync()
-	if err != nil {
-		fmt.Printf("failed to sync logger:  %v \n", err)
-	}
 	return nil
 }
 

--- a/crosslink/internal/prune.go
+++ b/crosslink/internal/prune.go
@@ -47,11 +47,6 @@ func Prune(rc RunConfig) error {
 				zap.Error(err))
 		}
 	}
-
-	err = rc.Logger.Sync()
-	if err != nil {
-		fmt.Printf("failed to sync logger:  %v", err)
-	}
 	return nil
 }
 

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.18
 require (
 	github.com/stretchr/testify v1.8.1
 	golang.org/x/mod v0.6.0
+	golang.org/x/sys v0.1.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -12,6 +12,8 @@ github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKs
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 golang.org/x/mod v0.6.0 h1:b9gGHsz9/HhJ3HF5DHQytPpuwocVTChQJK3AvoLRD5I=
 golang.org/x/mod v0.6.0/go.mod h1:4mET923SAdbXp2ki8ey+zGs1SLqsuM2Y0uvdZR/fUNI=
+golang.org/x/sys v0.1.0 h1:kunALQeHf1/185U1i0GOB/fy1IPRDDpuoOOqRReG57U=
+golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/internal/syncerror/known_sync_error.go
+++ b/internal/syncerror/known_sync_error.go
@@ -1,0 +1,46 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !windows
+// +build !windows
+
+package syncerror
+
+import (
+	"errors"
+	"syscall"
+)
+
+var knownSyncErrors = []error{
+	// sync /dev/stdout: invalid argument
+	syscall.EINVAL,
+	// sync /dev/stdout: not supported
+	syscall.ENOTSUP,
+	// sync /dev/stdout: inappropriate ioctl for device
+	syscall.ENOTTY,
+	// sync /dev/stdout: bad file descriptor
+	syscall.EBADF,
+}
+
+// knownSyncError returns true if the given error is one of the known
+// non-actionable errors returned by Sync on Linux and macOS.
+func KnownSyncError(err error) bool {
+	for _, syncError := range knownSyncErrors {
+		if errors.Is(err, syncError) {
+			return true
+		}
+	}
+
+	return false
+}

--- a/internal/syncerror/known_sync_error_test.go
+++ b/internal/syncerror/known_sync_error_test.go
@@ -1,0 +1,60 @@
+//go:build !windows
+// +build !windows
+
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package syncerror
+
+import (
+	"errors"
+	"syscall"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestKnownSyncError(t *testing.T) {
+	tests := []struct {
+		testName   string
+		assertion  assert.BoolAssertionFunc
+		errorValue error
+	}{
+		{
+			testName:   "einval",
+			assertion:  assert.True,
+			errorValue: syscall.EINVAL,
+		},
+		{
+			testName:   "enotsup",
+			assertion:  assert.True,
+			errorValue: syscall.ENOTSUP,
+		},
+		{
+			testName:   "enotty",
+			assertion:  assert.True,
+			errorValue: syscall.EBADF,
+		},
+		{
+			testName:   "fake error",
+			assertion:  assert.False,
+			errorValue: errors.New("invalid error"),
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.testName, func(t *testing.T) {
+			test.assertion(t, KnownSyncError(test.errorValue))
+		})
+	}
+}

--- a/internal/syncerror/known_sync_error_test.go
+++ b/internal/syncerror/known_sync_error_test.go
@@ -1,6 +1,3 @@
-//go:build !windows
-// +build !windows
-
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +11,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+//go:build !windows
+// +build !windows
 
 package syncerror
 

--- a/internal/syncerror/known_sync_error_windows.go
+++ b/internal/syncerror/known_sync_error_windows.go
@@ -1,0 +1,28 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build windows
+// +build windows
+
+package syncerror
+
+import "golang.org/x/sys/windows"
+
+// knownSyncError returns true if the given error is one of the known
+// non-actionable errors returned by Sync on Windows:
+//
+// - sync /dev/stderr: The handle is invalid.
+func KnownSyncError(err error) bool {
+	return err == windows.ERROR_INVALID_HANDLE
+}


### PR DESCRIPTION
Move logger.sync() method call to cobras `postRunSetup` and ignore `ENOTTY` error produced on unix systems. 


Fixes #190 