### PR TITLE
[multimod] Remove tag push, print instead. 

### DIFF
--- a/.chloggen/mm_printTags.yaml
+++ b/.chloggen/mm_printTags.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. crosslink)
+component: multimod
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Remove multimod tag push option in favor of printing tags
+
+# One or more tracking issues related to the change
+issues: [177]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/.chloggen/mm_printTags.yaml
+++ b/.chloggen/mm_printTags.yaml
@@ -1,5 +1,5 @@
 # One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
-change_type: bug_fix
+change_type: breaking
 
 # The name of the component, or a single word describing the area of concern, (e.g. crosslink)
 component: multimod

--- a/multimod/README.md
+++ b/multimod/README.md
@@ -122,16 +122,14 @@ commit will be found in your currently checked out branch.
     ./multimod tag --module-set-name <name> --commit-hash <hash>
     ```
 
-    **Note** Provide the `--push` flag if you would like multimod to push the
-    tags a remote repository automatically. You can also provide the `remote`
-    flag to specify which remote you would like to push to.
-    `remote` defaults to `upstream`.
+    **Note** Provide the `--print-tags` flag if you would like multimod to print tags
+    after tagging operations are done. This output will use a new-line delimiter.
 
     ```sh
-    ./multimod tag --module-set-name <name> --commit-hash <hash> --push
+    ./multimod tag --module-set-name <name> --commit-hash <hash> --print-tags
     ```
 
-2. If the `--publish` tag was not provided then tags must be pushed manually.
+3. Tags can then be pushed to a remote repository of your choice.
 
     ```sh
     git push upstream <new tag 1>

--- a/multimod/README.md
+++ b/multimod/README.md
@@ -129,7 +129,16 @@ commit will be found in your currently checked out branch.
     ./multimod tag --module-set-name <name> --commit-hash <hash> --print-tags
     ```
 
-3. Tags can then be pushed to a remote repository of your choice.
+    Using `--print-tags` allows `multimod tag` to be used in conjunction with tools
+    such as `xargs` to automatically push tags. Grepping the release version number
+    is required since multimod can output non tag related information to standard 
+    out. 
+    
+    ```sh
+    ./multimod tag --module-set-name $MOD_SET_NAME --commit-hash $MOD_SET_COMMIT --print-tags | grep $RELEASE_VER | xargs -L 1 git push $REMOTE_NAME
+    ```
+
+2. Tags can then be pushed to a remote repository of your choice.
 
     ```sh
     git push upstream <new tag 1>

--- a/multimod/README.md
+++ b/multimod/README.md
@@ -122,8 +122,9 @@ commit will be found in your currently checked out branch.
     ./multimod tag --module-set-name <name> --commit-hash <hash>
     ```
 
-    **Note** Provide the `--print-tags` flag if you would like multimod to print tags
-    after tagging operations are done. This output will use a new-line delimiter.
+    **Note** Provide the `--print-tags` flag if you would like multimod to print 
+    tags after tagging operations are done. This output will use a new-line
+    delimiter.
 
     ```sh
     ./multimod tag --module-set-name <name> --commit-hash <hash> --print-tags
@@ -131,11 +132,12 @@ commit will be found in your currently checked out branch.
 
     Using `--print-tags` allows `multimod tag` to be used in conjunction with tools
     such as `xargs` to automatically push tags. Grepping the release version number
-    is required since multimod can output non tag related information to standard 
-    out. 
-    
+    is required since multimod can output non tag related information to standard
+    out.
+
     ```sh
-    ./multimod tag --module-set-name $MOD_SET_NAME --commit-hash $MOD_SET_COMMIT --print-tags | grep $RELEASE_VER | xargs -L 1 git push $REMOTE_NAME
+    ./multimod tag --module-set-name $MOD_SET_NAME --commit-hash $MOD_SET_COMMIT 
+    --print-tags | grep $RELEASE_VER | xargs -L 1 git push $REMOTE_NAME
     ```
 
 2. Tags can then be pushed to a remote repository of your choice.

--- a/multimod/README.md
+++ b/multimod/README.md
@@ -122,9 +122,9 @@ commit will be found in your currently checked out branch.
     ./multimod tag --module-set-name <name> --commit-hash <hash>
     ```
 
-    **Note** Provide the `--print-tags` flag if you would like multimod to print 
-    tags after tagging operations are done. This output will use a new-line
-    delimiter.
+    **Note** Provide the `--print-tags` flag if you would like multimod to
+    print tags after tagging operations are done. This output will use a
+    new-line delimiter.
 
     ```sh
     ./multimod tag --module-set-name <name> --commit-hash <hash> --print-tags
@@ -136,8 +136,11 @@ commit will be found in your currently checked out branch.
     out.
 
     ```sh
-    ./multimod tag --module-set-name $MOD_SET_NAME --commit-hash $MOD_SET_COMMIT 
-    --print-tags | grep $RELEASE_VER | xargs -L 1 git push $REMOTE_NAME
+    ./multimod tag --module-set-name $MOD_SET_NAME \
+    --commit-hash $MOD_SET_COMMIT \
+    --print-tags \
+    | grep $RELEASE_VER \
+    | xargs -L 1 git push $REMOTE_NAME
     ```
 
 2. Tags can then be pushed to a remote repository of your choice.

--- a/multimod/cmd/tag.go
+++ b/multimod/cmd/tag.go
@@ -27,8 +27,6 @@ var (
 	commitHash          string
 	deleteModuleSetTags bool
 	moduleSetName       string
-	push                bool
-	remote              string
 )
 
 // tagCmd represents the tag command
@@ -41,7 +39,7 @@ var tagCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		fmt.Println("Using versioning file", versioningFile)
 
-		tag.Run(versioningFile, moduleSetName, commitHash, deleteModuleSetTags, push, remote)
+		tag.Run(versioningFile, moduleSetName, commitHash, deleteModuleSetTags)
 	},
 }
 
@@ -69,10 +67,4 @@ func init() {
 	tagCmd.Flags().BoolVarP(&deleteModuleSetTags, "delete-module-set-tags", "d", false,
 		"Specify this flag to delete all module tags associated with the version listed for the module set in the versioning file. Should only be used to undo recent tagging mistakes.",
 	)
-
-	tagCmd.Flags().BoolVarP(&push, "push-tags", "p", false, "Providing this"+
-		" flag will cause tags to be pushed to an upstream repository.")
-
-	tagCmd.Flags().StringVarP(&remote, "remote-name", "r", "upstream", "Name of the remote"+
-		"to push tags to.")
 }

--- a/multimod/cmd/tag.go
+++ b/multimod/cmd/tag.go
@@ -27,6 +27,7 @@ var (
 	commitHash          string
 	deleteModuleSetTags bool
 	moduleSetName       string
+	printTags           bool
 )
 
 // tagCmd represents the tag command
@@ -39,7 +40,7 @@ var tagCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		fmt.Println("Using versioning file", versioningFile)
 
-		tag.Run(versioningFile, moduleSetName, commitHash, deleteModuleSetTags)
+		tag.Run(versioningFile, moduleSetName, commitHash, deleteModuleSetTags, printTags)
 	},
 }
 
@@ -66,5 +67,9 @@ func init() {
 
 	tagCmd.Flags().BoolVarP(&deleteModuleSetTags, "delete-module-set-tags", "d", false,
 		"Specify this flag to delete all module tags associated with the version listed for the module set in the versioning file. Should only be used to undo recent tagging mistakes.",
+	)
+
+	tagCmd.Flags().BoolVarP(&printTags, "print-tags", "p", false,
+		"Specify this flag to print all tags after tagging is complete. Printed tags are new-line delimited.",
 	)
 }

--- a/multimod/internal/tag/tag.go
+++ b/multimod/internal/tag/tag.go
@@ -20,8 +20,6 @@ import (
 	"log"
 	"os/exec"
 
-	"github.com/go-git/go-git/v5/config"
-
 	"github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/go-git/go-git/v5/plumbing/object"
@@ -31,7 +29,7 @@ import (
 	"go.opentelemetry.io/build-tools/multimod/internal/common"
 )
 
-func Run(versioningFile, moduleSetName, commitHash string, deleteModuleSetTags bool, shouldPushTags bool, remote string) {
+func Run(versioningFile, moduleSetName, commitHash string, deleteModuleSetTags bool) {
 
 	repoRoot, err := repo.FindRoot()
 	if err != nil {
@@ -55,12 +53,6 @@ func Run(versioningFile, moduleSetName, commitHash string, deleteModuleSetTags b
 	} else {
 		if err := t.tagAllModules(nil); err != nil {
 			log.Fatalf("unable to tag modules: %v", err)
-		}
-	}
-
-	if shouldPushTags {
-		if err := pushTags(t.ModuleSetRelease.ModuleFullTagNames(), t.Repo, remote); err != nil {
-			log.Fatalf("failed to pushTags tags: %v", err)
 		}
 	}
 }
@@ -229,33 +221,5 @@ func (t tagger) tagAllModules(customTagger *object.Signature) error {
 		addedFullTags = append(addedFullTags, newFullTag)
 	}
 
-	return nil
-}
-
-func pushTags(tagsToPush []string, repo *git.Repository, remote string) error {
-
-	for _, fullTageName := range tagsToPush {
-		tagref, err := repo.Tag(fullTageName)
-		if err != nil {
-			return fmt.Errorf("unable to fetch git tag ref for %v: %w", fullTageName, err)
-		}
-		refName := fmt.Sprintf("%s:%s", tagref.Name(), tagref.Name())
-		rs := config.RefSpec(refName)
-		err = rs.Validate()
-		if err != nil {
-			return fmt.Errorf("failed validation for refspec %s:%w", rs.String(), err)
-		}
-		err = repo.Push(&git.PushOptions{
-			RefSpecs:   []config.RefSpec{rs},
-			RemoteName: remote,
-		})
-		if err != nil {
-			if errors.Is(err, git.NoErrAlreadyUpToDate) {
-				log.Printf("tag %s is is already present on remote %s", tagref.Name(), remote)
-			} else {
-				return fmt.Errorf("error pushing tag %s:%w", tagref.Name(), err)
-			}
-		}
-	}
 	return nil
 }

--- a/multimod/internal/tag/tag.go
+++ b/multimod/internal/tag/tag.go
@@ -29,7 +29,7 @@ import (
 	"go.opentelemetry.io/build-tools/multimod/internal/common"
 )
 
-func Run(versioningFile, moduleSetName, commitHash string, deleteModuleSetTags bool) {
+func Run(versioningFile, moduleSetName, commitHash string, deleteModuleSetTags bool, shouldPrintTags bool) {
 
 	repoRoot, err := repo.FindRoot()
 	if err != nil {
@@ -53,6 +53,12 @@ func Run(versioningFile, moduleSetName, commitHash string, deleteModuleSetTags b
 	} else {
 		if err := t.tagAllModules(nil); err != nil {
 			log.Fatalf("unable to tag modules: %v", err)
+		}
+	}
+
+	if shouldPrintTags {
+		for _, tag := range t.ModuleFullTagNames() {
+			fmt.Println(tag)
 		}
 	}
 }

--- a/multimod/internal/tag/tag_test.go
+++ b/multimod/internal/tag/tag_test.go
@@ -19,10 +19,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
-	"reflect"
 	"testing"
-
-	"github.com/go-git/go-git/v5/config"
 
 	"github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/plumbing"
@@ -597,118 +594,4 @@ func TestTagAllModules(t *testing.T) {
 		})
 	}
 
-}
-
-func TestTagPush(t *testing.T) {
-	originRepoDir := t.TempDir()
-	originRepo, firstHash, err := commontest.InitNewRepoWithCommit(originRepoDir)
-	require.NoError(t, err)
-
-	secondHash, err := common.CommitChangesToNewBranch("test_commit", "commit used in a test", originRepo, commontest.TestAuthor)
-	require.NoError(t, err)
-
-	createTagOptions := &git.CreateTagOptions{
-		Message: "test tag message",
-		Tagger:  commontest.TestAuthor,
-	}
-
-	for _, tagName := range []string{
-		"test_tag_first_hash_1/v1.0.0",
-		"test_tag_first_hash_2/v1.0.0",
-		"test_tag_first_hash_3/v1.0.0",
-	} {
-		_, err = originRepo.CreateTag(tagName, firstHash, createTagOptions)
-		require.NoError(t, err)
-	}
-
-	for _, tagName := range []string{
-		"test_tag_second_hash_1/v1.0.0",
-		"test_tag_second_hash_2/v1.0.0",
-		"test_tag_second_hash_3/v1.0.0",
-	} {
-		_, err = originRepo.CreateTag(tagName, secondHash, createTagOptions)
-		require.NoError(t, err)
-	}
-
-	testCases := []struct {
-		name              string
-		moduleFullTags    []string
-		shouldErrorAssert assert.ErrorAssertionFunc
-		shouldMatchAssert assert.BoolAssertionFunc
-	}{
-		{
-			name: "tags_exist",
-			moduleFullTags: []string{
-				"test_tag_first_hash_1/v1.0.0",
-				"test_tag_first_hash_2/v1.0.0",
-				"test_tag_first_hash_3/v1.0.0",
-				"test_tag_second_hash_1/v1.0.0",
-				"test_tag_second_hash_2/v1.0.0",
-				"test_tag_second_hash_3/v1.0.0",
-			},
-			shouldMatchAssert: assert.True,
-			shouldErrorAssert: assert.NoError,
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			upstreamRepoDir := t.TempDir()
-
-			upstreamRepo, err := git.PlainInit(upstreamRepoDir, true)
-			require.NoError(t, err)
-			_, err = originRepo.CreateRemote(&config.RemoteConfig{Name: "upstream", URLs: []string{upstreamRepoDir}})
-
-			require.NoError(t, err)
-
-			refCommitMap := make(map[string]string)
-			for _, tagName := range tc.moduleFullTags {
-				var tagRef *plumbing.Reference
-				tagRef, err = originRepo.Tag(tagName)
-				require.NoError(t, err)
-				refCommitMap[tagRef.Name().String()] = tagRef.Hash().String()
-			}
-
-			err = pushTags(tc.moduleFullTags, originRepo, "upstream")
-			require.NoError(t, err)
-
-			for name, target := range refCommitMap {
-				var actual *plumbing.Reference
-				expected := plumbing.NewReferenceFromStrings(name, target)
-				actual, err = upstreamRepo.Reference(expected.Name(), true)
-				tc.shouldErrorAssert(t, err)
-
-				matches := reflect.DeepEqual(actual, expected)
-				tc.shouldMatchAssert(t, matches)
-			}
-			err = originRepo.DeleteRemote("upstream")
-			require.NoError(t, err)
-		})
-
-	}
-}
-
-func TestPushTags_BadRemote(t *testing.T) {
-	originRepoDir := t.TempDir()
-	originRepo, firstHash, err := commontest.InitNewRepoWithCommit(originRepoDir)
-	require.NoError(t, err)
-
-	createTagOptions := &git.CreateTagOptions{
-		Message: "test tag message",
-		Tagger:  commontest.TestAuthor,
-	}
-
-	tagsToPush := []string{
-		"test_tag_first_hash_1/v1.0.0",
-		"test_tag_first_hash_2/v1.0.0",
-		"test_tag_first_hash_3/v1.0.0",
-	}
-
-	for _, tagName := range tagsToPush {
-		_, err = originRepo.CreateTag(tagName, firstHash, createTagOptions)
-		require.NoError(t, err)
-	}
-
-	err = pushTags(tagsToPush, originRepo, "upstream")
-	assert.Error(t, err)
 }


### PR DESCRIPTION
This PR removes the `--push` flag on `multimod tag`. As shown in issue #177 `push` required additional authentication to be set up since it did not natively read git credentials from the environment. Multiple options were discussed in #177. This PR implements the last suggestion which prints all tags separated by a newline. This `--print-tags` option can then be worked into existing repositories release process.

The `push` code has been removed from multimod. I believe the `os.exec` option is still possible but I have not had time to address it. This option provides a quick win while also removing bugged code. I suggest we reopen #157 which can be assigned and investigated in the future. 

Fixes #177 

```
bryaag@147ddac12c15 multimod % ./multimod tag --module-set-name tools --commit-hash ba1996ae547f1db9f1925961950b97fc6cf2a636 --print-tags | grep v0.2.0 |  xargs -L 1 echo testOutput  
Tagging commit ba1996ae547f1db9f1925961950b97fc6cf2a636:
v0.2.0
checkdoc/v0.2.0
chloggen/v0.2.0
crosslink/v0.2.0
dbotconf/v0.2.0
issuegenerator/v0.2.0
multimod/v0.2.0
semconvgen/v0.2.0
testOutput v0.2.0
testOutput checkdoc/v0.2.0
testOutput chloggen/v0.2.0
testOutput crosslink/v0.2.0
testOutput dbotconf/v0.2.0
testOutput issuegenerator/v0.2.0
testOutput multimod/v0.2.0
testOutput semconvgen/v0.2.0
```