### PR TITLE
[chore] add github action to make updating dependencies easier

### DIFF
--- a/.github/workflows/create-dependabot-pr.yml
+++ b/.github/workflows/create-dependabot-pr.yml
@@ -1,4 +1,4 @@
-name: dependabot-pr
+name: Automation - Dependabot PR
 
 on:
   workflow_dispatch:
@@ -8,10 +8,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+
+      - name: Install zsh
+        run: sudo apt-get update; sudo apt-get install zsh
+
       - name: Setup Go
         uses: actions/setup-go@v3
         with:
           go-version: 1.19
+
       - name: Run dependabot-pr.sh
         run: ./.github/workflows/scripts/dependabot-pr.sh
         env:

--- a/.github/workflows/create-dependabot-pr.yml
+++ b/.github/workflows/create-dependabot-pr.yml
@@ -1,0 +1,18 @@
+name: dependabot-pr
+
+on:
+  workflow_dispatch:
+
+jobs:
+  create-pr:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: 1.19
+      - name: Run dependabot-pr.sh
+        run: ./.github/workflows/scripts/dependabot-pr.sh
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/scripts/dependabot-pr.sh
+++ b/.github/workflows/scripts/dependabot-pr.sh
@@ -1,40 +1,61 @@
-#!/bin/bash -ex
+#!/bin/zsh -ex
+
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 git config user.name "$GITHUB_ACTOR"
 git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
-# shellcheck disable=SC2006
-PR_NAME=dependabot-prs/$(date +'%Y-%m-%dT%H%M%S')
-git checkout -b "$PR_NAME"
+PR_NAME=dependabot-prs/`date +'%Y-%m-%dT%H%M%S'`
+git checkout -b $PR_NAME
 
 IFS=$'\n'
-requests=$( gh pr list --search "author:app/dependabot" --json title --jq '.[].title' | sort )
+requests=($( gh pr list --search "author:app/dependabot" --json title --jq '.[].title' ))
 message=""
-dirs=$(find . -type f -name "go.mod" -exec dirname {} \; | sort )
+dirs=(`find . -type f -name "go.mod" -exec dirname {} \; | sort | egrep  '^./'`)
+
+declare -A mods
 
 for line in $requests; do
-    if [[ $line != Bump* ]]; then
+    echo $line
+    if [[ $line != build\(deps\)* ]]; then
         continue
     fi
 
-    module=$(echo "$line" | cut -f 2 -d " ")
-    version=$(echo "$line" | cut -f 6 -d " ")
-    
-    topdir=$(pwd)
-    for dir in $dirs; do
-        echo "checking $dir"
-        cd "$dir" && if grep -q "$module " go.mod; then go get "$module"@v"$version"; fi
-        cd $topdir
-    done
+    module=$(echo $line | cut -f 2 -d " ")
+    version=$(echo $line | cut -f 6 -d " ")
+
+    mods[$module]=$version
     message+=$line
     message+=$'\n'
 done
 
-make tidy lint
+for module version in ${(kv)mods}; do
+    topdir=`pwd`
+    for dir in $dirs; do
+        echo "checking $dir"
+        cd $dir && if grep -q "$module " go.mod; then go get "$module"@v"$version"; fi
+        cd $topdir
+    done
+done
 
-git add --all
-git commit -m "dependabot updates $(date)
+make tidy lint build
+
+git add go.sum go.mod
+git add "**/go.sum" "**/go.mod"
+git commit -m "dependabot updates `date`
 $message"
-git push origin "$PR_NAME"
+git push origin $PR_NAME
 
-gh pr create --title "[chore] dependabot updates $(date)" --body "$message" -l "dependencies"
+gh pr create --title "dependabot updates `date`" --body "$message"

--- a/.github/workflows/scripts/dependabot-pr.sh
+++ b/.github/workflows/scripts/dependabot-pr.sh
@@ -1,0 +1,40 @@
+#!/bin/bash -ex
+
+git config user.name "$GITHUB_ACTOR"
+git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+
+# shellcheck disable=SC2006
+PR_NAME=dependabot-prs/$(date +'%Y-%m-%dT%H%M%S')
+git checkout -b "$PR_NAME"
+
+IFS=$'\n'
+requests=$( gh pr list --search "author:app/dependabot" --json title --jq '.[].title' | sort )
+message=""
+dirs=$(find . -type f -name "go.mod" -exec dirname {} \; | sort )
+
+for line in $requests; do
+    if [[ $line != Bump* ]]; then
+        continue
+    fi
+
+    module=$(echo "$line" | cut -f 2 -d " ")
+    version=$(echo "$line" | cut -f 6 -d " ")
+    
+    topdir=$(pwd)
+    for dir in $dirs; do
+        echo "checking $dir"
+        cd "$dir" && if grep -q "$module " go.mod; then go get "$module"@v"$version"; fi
+        cd $topdir
+    done
+    message+=$line
+    message+=$'\n'
+done
+
+make tidy lint
+
+git add --all
+git commit -m "dependabot updates $(date)
+$message"
+git push origin "$PR_NAME"
+
+gh pr create --title "[chore] dependabot updates $(date)" --body "$message" -l "dependencies"


### PR DESCRIPTION
This is the same script that is used in the collector/collector-contrib repos to handle updating the dependencies and tidying the repository.

Signed-off-by: Alex Boten <aboten@lightstep.com>