### PR TITLE
[chore] update dependabot pr script

### DIFF
--- a/.github/workflows/scripts/dependabot-pr.sh
+++ b/.github/workflows/scripts/dependabot-pr.sh
@@ -58,4 +58,4 @@ git commit -m "dependabot updates `date`
 $message"
 git push origin $PR_NAME
 
-gh pr create --title "dependabot updates `date`" --body "$message" -l "Skip Changelog"
+gh pr create --title "[chore] dependabot updates `date`" --body "$message"


### PR DESCRIPTION
This removes the need for the "Skip changelog" label and update the title to contain "[chore]". This works around the issue that opentelemetrybot doesnt have permission to edit a PR and add a label to it.

Signed-off-by: Alex Boten <aboten@lightstep.com>