### PR TITLE
bump minimum go version to 1.19

### DIFF
--- a/.chloggen/codeboten_bump-minimum.yaml
+++ b/.chloggen/codeboten_bump-minimum.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. crosslink)
+component: all
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: bump minimum go version to 1.19
+
+# One or more tracking issues related to the change
+issues: [253]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ env:
   # Path to where test results will be saved.
   TEST_RESULTS: /tmp/test-results
   # Default minimum version of Go to support.
-  DEFAULT_GO_VERSION: 1.18
+  DEFAULT_GO_VERSION: 1.19
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/checkdoc/go.mod
+++ b/checkdoc/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/build-tools/checkdoc
 
-go 1.18
+go 1.19
 
 require github.com/stretchr/testify v1.8.1
 

--- a/chloggen/go.mod
+++ b/chloggen/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/build-tools/chloggen
 
-go 1.18
+go 1.19
 
 require (
 	github.com/spf13/cobra v1.6.1

--- a/crosslink/go.mod
+++ b/crosslink/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/build-tools/crosslink
 
-go 1.18
+go 1.19
 
 require (
 	github.com/google/go-cmp v0.5.9

--- a/crosslink/internal/crosslink_test.go
+++ b/crosslink/internal/crosslink_test.go
@@ -43,7 +43,7 @@ func TestCrosslink(t *testing.T) {
 			config:   DefaultRunConfig(),
 			expected: map[string][]byte{
 				"go.mod": []byte("module go.opentelemetry.io/build-tools/crosslink/testroot\n\n" +
-					"go 1.18\n\n" +
+					"go 1.19\n\n" +
 					"require (\n\t" +
 					"go.opentelemetry.io/build-tools/crosslink/testroot/testA v1.0.0\n" +
 					")\n" +
@@ -52,13 +52,13 @@ func TestCrosslink(t *testing.T) {
 					"replace go.opentelemetry.io/build-tools/crosslink/testroot/testZ => ./testZ\n\n" +
 					"replace go.opentelemetry.io/build-tools/crosslink/testroot/testB => ./testB"),
 				filepath.Join("testA", "go.mod"): []byte("module go.opentelemetry.io/build-tools/crosslink/testroot/testA\n\n" +
-					"go 1.18\n\n" +
+					"go 1.19\n\n" +
 					"require (\n\t" +
 					"go.opentelemetry.io/build-tools/crosslink/testroot/testB v1.0.0\n" +
 					")\n" +
 					"replace go.opentelemetry.io/build-tools/crosslink/testroot/testB => ../testB"),
 				filepath.Join("testB", "go.mod"): []byte("module go.opentelemetry.io/build-tools/crosslink/testroot/testB\n\n" +
-					"go 1.18\n\n"),
+					"go 1.19\n\n"),
 			},
 		},
 		{
@@ -67,14 +67,14 @@ func TestCrosslink(t *testing.T) {
 			config:   DefaultRunConfig(),
 			expected: map[string][]byte{
 				"go.mod": []byte("module go.opentelemetry.io/build-tools/crosslink/testroot\n\n" +
-					"go 1.18\n\n" +
+					"go 1.19\n\n" +
 					"require (\n\t" +
 					"go.opentelemetry.io/build-tools/crosslink/testroot/testA v1.0.0\n" +
 					")\n" +
 					"replace go.opentelemetry.io/build-tools/crosslink/testroot/testA => ./testA\n\n" +
 					"replace go.opentelemetry.io/build-tools/crosslink/testroot/testB => ./testB"),
 				filepath.Join("testA", "go.mod"): []byte("module go.opentelemetry.io/build-tools/crosslink/testroot/testA\n\n" +
-					"go 1.18\n\n" +
+					"go 1.19\n\n" +
 					"require (\n\t" +
 					"go.opentelemetry.io/build-tools/crosslink/testroot/testB v1.0.0\n" +
 					")\n" +
@@ -82,7 +82,7 @@ func TestCrosslink(t *testing.T) {
 					"replace go.opentelemetry.io/build-tools/crosslink/testroot => ../"),
 				// b has req on root but not necessary to write out with current comparison logic
 				filepath.Join("testB", "go.mod"): []byte("module go.opentelemetry.io/build-tools/crosslink/testroot/testB\n\n" +
-					"go 1.18\n\n" +
+					"go 1.19\n\n" +
 					"replace go.opentelemetry.io/build-tools/crosslink/testroot/testA => ../testA\n\n" +
 					"replace go.opentelemetry.io/build-tools/crosslink/testroot => ../\n\n"),
 			},
@@ -96,20 +96,20 @@ func TestCrosslink(t *testing.T) {
 			},
 			expected: map[string][]byte{
 				"go.mod": []byte("module go.opentelemetry.io/build-tools/crosslink/testroot\n\n" +
-					"go 1.18\n\n" +
+					"go 1.19\n\n" +
 					"require (\n\t" +
 					"go.opentelemetry.io/build-tools/crosslink/testroot/testA v1.0.0\n" +
 					")\n" +
 					"replace go.opentelemetry.io/build-tools/crosslink/testroot/testA => ./testA\n\n" +
 					"replace go.opentelemetry.io/build-tools/crosslink/testroot/testB => ./testB"),
 				filepath.Join("testA", "go.mod"): []byte("module go.opentelemetry.io/build-tools/crosslink/testroot/testA\n\n" +
-					"go 1.18\n\n" +
+					"go 1.19\n\n" +
 					"require (\n\t" +
 					"go.opentelemetry.io/build-tools/crosslink/testroot/testB v1.0.0\n" +
 					")\n" +
 					"replace go.opentelemetry.io/build-tools/crosslink/testroot/testB => ../testB"),
 				filepath.Join("testB", "go.mod"): []byte("module go.opentelemetry.io/build-tools/crosslink/testroot/testB\n\n" +
-					"go 1.18\n\n"),
+					"go 1.19\n\n"),
 			},
 		},
 	}
@@ -188,20 +188,20 @@ func TestOverwrite(t *testing.T) {
 			},
 			expected: map[string][]byte{
 				"go.mod": []byte("module go.opentelemetry.io/build-tools/crosslink/testroot\n\n" +
-					"go 1.18\n\n" +
+					"go 1.19\n\n" +
 					"require (\n\t" +
 					"go.opentelemetry.io/build-tools/crosslink/testroot/testA v1.0.0\n" +
 					")\n" +
 					"replace go.opentelemetry.io/build-tools/crosslink/testroot/testA => ./testA\n\n" +
 					"replace go.opentelemetry.io/build-tools/crosslink/testroot/testB => ./testB"),
 				filepath.Join("testA", "go.mod"): []byte("module go.opentelemetry.io/build-tools/crosslink/testroot/testA\n\n" +
-					"go 1.18\n\n" +
+					"go 1.19\n\n" +
 					"require (\n\t" +
 					"go.opentelemetry.io/build-tools/crosslink/testroot/testB v1.0.0\n" +
 					")\n" +
 					"replace go.opentelemetry.io/build-tools/crosslink/testroot/testB => ../testB"),
 				filepath.Join("testB", "go.mod"): []byte("module go.opentelemetry.io/build-tools/crosslink/testroot/testB\n\n" +
-					"go 1.18\n\n"),
+					"go 1.19\n\n"),
 			},
 		},
 		{
@@ -213,20 +213,20 @@ func TestOverwrite(t *testing.T) {
 			},
 			expected: map[string][]byte{
 				"go.mod": []byte("module go.opentelemetry.io/build-tools/crosslink/testroot\n\n" +
-					"go 1.18\n\n" +
+					"go 1.19\n\n" +
 					"require (\n\t" +
 					"go.opentelemetry.io/build-tools/crosslink/testroot/testA v1.0.0\n" +
 					")\n" +
 					"replace go.opentelemetry.io/build-tools/crosslink/testroot/testA => ../testA\n\n" +
 					"replace go.opentelemetry.io/build-tools/crosslink/testroot/testB => ./testB"),
 				filepath.Join("testA", "go.mod"): []byte("module go.opentelemetry.io/build-tools/crosslink/testroot/testA\n\n" +
-					"go 1.18\n\n" +
+					"go 1.19\n\n" +
 					"require (\n\t" +
 					"go.opentelemetry.io/build-tools/crosslink/testroot/testB v1.0.0\n" +
 					")\n" +
 					"replace go.opentelemetry.io/build-tools/crosslink/testroot/testB => ../testB"),
 				filepath.Join("testB", "go.mod"): []byte("module go.opentelemetry.io/build-tools/crosslink/testroot/testB\n\n" +
-					"go 1.18\n\n"),
+					"go 1.19\n\n"),
 			},
 		},
 	}
@@ -352,20 +352,20 @@ func TestExclude(t *testing.T) {
 				// a mock_test_data_expected folder could be built instead of building expected files by hand.
 				modFilesExpected := map[string][]byte{
 					filepath.Join(tmpRootDir, "go.mod"): []byte("module go.opentelemetry.io/build-tools/crosslink/testroot\n\n" +
-						"go 1.18\n\n" +
+						"go 1.19\n\n" +
 						"require (\n\t" +
 						"go.opentelemetry.io/build-tools/crosslink/testroot/testA v1.0.0\n" +
 						")\n" +
 						"replace go.opentelemetry.io/build-tools/crosslink/testroot/testA => ../testA\n\n" +
 						"replace go.opentelemetry.io/build-tools/excludeme => ../excludeme\n\n"),
 					filepath.Join(tmpRootDir, "testA", "go.mod"): []byte("module go.opentelemetry.io/build-tools/crosslink/testroot/testA\n\n" +
-						"go 1.18\n\n" +
+						"go 1.19\n\n" +
 						"require (\n\t" +
 						"go.opentelemetry.io/build-tools/crosslink/testroot/testB v1.0.0\n" +
 						")\n" +
 						"replace go.opentelemetry.io/build-tools/crosslink/testroot/testB => ../testB"),
 					filepath.Join(tmpRootDir, "testB", "go.mod"): []byte("module go.opentelemetry.io/build-tools/crosslink/testroot/testB\n\n" +
-						"go 1.18\n\n"),
+						"go 1.19\n\n"),
 				}
 
 				for modFilePath, modFilesExpected := range modFilesExpected {

--- a/crosslink/internal/mock_test_data/testCyclic/gomod
+++ b/crosslink/internal/mock_test_data/testCyclic/gomod
@@ -1,5 +1,5 @@
 module go.opentelemetry.io/build-tools/crosslink/testroot
 
-go 1.18
+go 1.19
 
 require go.opentelemetry.io/build-tools/crosslink/testroot/testA v1.0.0

--- a/crosslink/internal/mock_test_data/testCyclic/testA/gomod
+++ b/crosslink/internal/mock_test_data/testCyclic/testA/gomod
@@ -1,5 +1,5 @@
 module go.opentelemetry.io/build-tools/crosslink/testroot/testA
 
-go 1.18
+go 1.19
 
 require go.opentelemetry.io/build-tools/crosslink/testroot/testB v1.0.0

--- a/crosslink/internal/mock_test_data/testCyclic/testB/gomod
+++ b/crosslink/internal/mock_test_data/testCyclic/testB/gomod
@@ -1,5 +1,5 @@
 module go.opentelemetry.io/build-tools/crosslink/testroot/testB
 
-go 1.18
+go 1.19
 
 require go.opentelemetry.io/build-tools/crosslink/testroot v1.0.0

--- a/crosslink/internal/mock_test_data/testExclude/gomod
+++ b/crosslink/internal/mock_test_data/testExclude/gomod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/build-tools/crosslink/testroot
 
-go 1.18
+go 1.19
 
 require go.opentelemetry.io/build-tools/crosslink/testroot/testA v1.0.0
 

--- a/crosslink/internal/mock_test_data/testExclude/testA/gomod
+++ b/crosslink/internal/mock_test_data/testExclude/testA/gomod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/build-tools/crosslink/testroot/testA
 
-go 1.18
+go 1.19
 
 require go.opentelemetry.io/build-tools/crosslink/testroot/testB v1.0.0
 

--- a/crosslink/internal/mock_test_data/testExclude/testB/gomod
+++ b/crosslink/internal/mock_test_data/testExclude/testB/gomod
@@ -1,3 +1,3 @@
 module go.opentelemetry.io/build-tools/crosslink/testroot/testB
 
-go 1.18
+go 1.19

--- a/crosslink/internal/mock_test_data/testNoOverwrite/gomod
+++ b/crosslink/internal/mock_test_data/testNoOverwrite/gomod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/build-tools/crosslink/testroot
 
-go 1.18
+go 1.19
 
 require go.opentelemetry.io/build-tools/crosslink/testroot/testA v1.0.0
 

--- a/crosslink/internal/mock_test_data/testNoOverwrite/testA/gomod
+++ b/crosslink/internal/mock_test_data/testNoOverwrite/testA/gomod
@@ -1,5 +1,5 @@
 module go.opentelemetry.io/build-tools/crosslink/testroot/testA
 
-go 1.18
+go 1.19
 
 require go.opentelemetry.io/build-tools/crosslink/testroot/testB v1.0.0

--- a/crosslink/internal/mock_test_data/testNoOverwrite/testB/gomod
+++ b/crosslink/internal/mock_test_data/testNoOverwrite/testB/gomod
@@ -1,3 +1,3 @@
 module go.opentelemetry.io/build-tools/crosslink/testroot/testB
 
-go 1.18
+go 1.19

--- a/crosslink/internal/mock_test_data/testOverwrite/gomod
+++ b/crosslink/internal/mock_test_data/testOverwrite/gomod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/build-tools/crosslink/testroot
 
-go 1.18
+go 1.19
 
 require go.opentelemetry.io/build-tools/crosslink/testroot/testA v1.0.0
 

--- a/crosslink/internal/mock_test_data/testOverwrite/testA/gomod
+++ b/crosslink/internal/mock_test_data/testOverwrite/testA/gomod
@@ -1,5 +1,5 @@
 module go.opentelemetry.io/build-tools/crosslink/testroot/testA
 
-go 1.18
+go 1.19
 
 require go.opentelemetry.io/build-tools/crosslink/testroot/testB v1.0.0

--- a/crosslink/internal/mock_test_data/testOverwrite/testB/gomod
+++ b/crosslink/internal/mock_test_data/testOverwrite/testB/gomod
@@ -1,3 +1,3 @@
 module go.opentelemetry.io/build-tools/crosslink/testroot/testB
 
-go 1.18
+go 1.19

--- a/crosslink/internal/mock_test_data/testPrune/gomod
+++ b/crosslink/internal/mock_test_data/testPrune/gomod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/build-tools/crosslink/testroot
 
-go 1.18
+go 1.19
 
 require (
     go.opentelemetry.io/build-tools/crosslink/testroot/testA v1.0.0

--- a/crosslink/internal/mock_test_data/testSimple/gomod
+++ b/crosslink/internal/mock_test_data/testSimple/gomod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/build-tools/crosslink/testroot
 
-go 1.18
+go 1.19
 
 require go.opentelemetry.io/build-tools/crosslink/testroot/testA v1.0.0
 

--- a/crosslink/internal/mock_test_data/testSimple/testA/gomod
+++ b/crosslink/internal/mock_test_data/testSimple/testA/gomod
@@ -1,5 +1,5 @@
 module go.opentelemetry.io/build-tools/crosslink/testroot/testA
 
-go 1.18
+go 1.19
 
 require go.opentelemetry.io/build-tools/crosslink/testroot/testB v1.0.0

--- a/crosslink/internal/mock_test_data/testSimple/testB/gomod
+++ b/crosslink/internal/mock_test_data/testSimple/testB/gomod
@@ -1,3 +1,3 @@
 module go.opentelemetry.io/build-tools/crosslink/testroot/testB
 
-go 1.18
+go 1.19

--- a/crosslink/internal/mock_test_data/testSimplePrune/gomod
+++ b/crosslink/internal/mock_test_data/testSimplePrune/gomod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/build-tools/crosslink/testroot
 
-go 1.18
+go 1.19
 
 require go.opentelemetry.io/build-tools/crosslink/testroot/testA v1.0.0
 

--- a/crosslink/internal/mock_test_data/testSimplePrune/testA/gomod
+++ b/crosslink/internal/mock_test_data/testSimplePrune/testA/gomod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/build-tools/crosslink/testroot/testA
 
-go 1.18
+go 1.19
 
 require go.opentelemetry.io/build-tools/crosslink/testroot/testB v1.0.0
 

--- a/crosslink/internal/mock_test_data/testSimplePrune/testB/gomod
+++ b/crosslink/internal/mock_test_data/testSimplePrune/testB/gomod
@@ -1,3 +1,3 @@
 module go.opentelemetry.io/build-tools/crosslink/testroot/testB
 
-go 1.18
+go 1.19

--- a/crosslink/internal/prune_test.go
+++ b/crosslink/internal/prune_test.go
@@ -46,20 +46,20 @@ func TestPrune(t *testing.T) {
 			},
 			expected: map[string][]byte{
 				"go.mod": []byte("module go.opentelemetry.io/build-tools/crosslink/testroot\n\n" +
-					"go 1.18\n\n" +
+					"go 1.19\n\n" +
 					"require (\n\t" +
 					"go.opentelemetry.io/build-tools/crosslink/testroot/testA v1.0.0\n" +
 					")\n" +
 					"replace go.opentelemetry.io/build-tools/crosslink/testroot/testA => ./testA\n\n" +
 					"replace go.opentelemetry.io/build-tools/crosslink/testroot/testB => ./testB"),
 				filepath.Join("testA", "go.mod"): []byte("module go.opentelemetry.io/build-tools/crosslink/testroot/testA\n\n" +
-					"go 1.18\n\n" +
+					"go 1.19\n\n" +
 					"require (\n\t" +
 					"go.opentelemetry.io/build-tools/crosslink/testroot/testB v1.0.0\n" +
 					")\n" +
 					"replace go.opentelemetry.io/build-tools/crosslink/testroot/testB => ../testB"),
 				filepath.Join("testB", "go.mod"): []byte("module go.opentelemetry.io/build-tools/crosslink/testroot/testB\n\n" +
-					"go 1.18\n\n"),
+					"go 1.19\n\n"),
 			},
 		},
 	}
@@ -162,7 +162,7 @@ func TestPruneReplace(t *testing.T) {
 	pruneReplace("go.opentelemetry.io/build-tools/crosslink/testroot", mockModInfo, RunConfig{Prune: true, Verbose: true, Logger: lg})
 
 	expectedModFile := []byte("module go.opentelemetry.io/build-tools/crosslink/testroot\n\n" +
-		"go 1.18\n\n" +
+		"go 1.19\n\n" +
 		"require (\n\t" +
 		"go.opentelemetry.io/build-tools/crosslink/testroot/testA v1.0.0\n" +
 		"go.opentelemetry.io/build-tools/crosslink/testroot/testB v1.0.0\n" +

--- a/dbotconf/go.mod
+++ b/dbotconf/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/build-tools/dbotconf
 
-go 1.18
+go 1.19
 
 require (
 	github.com/spf13/cobra v1.6.1

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/build-tools
 
-go 1.18
+go 1.19
 
 require (
 	github.com/stretchr/testify v1.8.1

--- a/internal/repo/repo_test.go
+++ b/internal/repo/repo_test.go
@@ -93,7 +93,7 @@ func TestFindDockerfiles(t *testing.T) {
 		dFile := filepath.Join(path.dir, path.file)
 		f, err := os.Create(filepath.Clean(dFile))
 		require.NoError(t, err)
-		fmt.Fprint(f, "FROM golang:1.18-alpine\n")
+		fmt.Fprint(f, "FROM golang:1.19-alpine\n")
 		require.NoError(t, f.Close())
 	}
 	// Add an empty dir.

--- a/internal/tools/go.mod
+++ b/internal/tools/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/build-tools/internal/tools
 
-go 1.18
+go 1.19
 
 require (
 	github.com/client9/misspell v0.3.4

--- a/issuegenerator/go.mod
+++ b/issuegenerator/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/build-tools/issuegenerator
 
-go 1.18
+go 1.19
 
 require (
 	github.com/google/go-github v17.0.0+incompatible

--- a/multimod/go.mod
+++ b/multimod/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/build-tools/multimod
 
-go 1.18
+go 1.19
 
 require (
 	github.com/go-git/go-git/v5 v5.5.2

--- a/semconvgen/go.mod
+++ b/semconvgen/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/build-tools/semconvgen
 
-go 1.18
+go 1.19
 
 require (
 	github.com/spf13/pflag v1.0.5


### PR DESCRIPTION
Some dependencies require go 1.19+ https://github.com/open-telemetry/opentelemetry-go-build-tools/actions/runs/4205777490/jobs/7298348033