### PR TITLE
crosslink: Add work command

### DIFF
--- a/.chloggen/crosslink-work.yaml
+++ b/.chloggen/crosslink-work.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. crosslink)
+component: crosslink
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Add work command generating go.work file."
+
+# One or more tracking issues related to the change
+issues: [309]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,7 @@ Thumbs.db
 *.iml
 *.so
 coverage.*
-go.work
+/go.work
 go.work.sum
 
 crosslink/internal/test_data/

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,9 @@ coverage.*
 go.work
 go.work.sum
 
+crosslink/internal/test_data/
+!crosslink/internal/test_data/.placeholder
+
 checkdoc/checkdoc
 chloggen/chloggen
 crosslink/crosslink

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@ Thumbs.db
 *.iml
 *.so
 coverage.*
+go.work
+go.work.sum
 
 checkdoc/checkdoc
 chloggen/chloggen

--- a/Makefile
+++ b/Makefile
@@ -208,3 +208,8 @@ chlog-update: | $(CHLOGGEN)
 crosslink: | $(CROSSLINK)
 	@echo "Updating intra-repository dependencies in all go modules" \
 		&& $(CROSSLINK) --root=$(shell pwd) --prune
+
+.PHONY: gowork
+gowork: | $(CROSSLINK)
+	$(CROSSLINK) work --root=$(shell pwd)
+

--- a/crosslink/README.md
+++ b/crosslink/README.md
@@ -3,6 +3,8 @@
 Crosslink is a tool to assist in managing go repositories that contain multiple
 intra-repository `go.mod` files. Crosslink automatically scans and inserts
 replace statements for direct and transitive intra-repository dependencies.
+Crosslink can generate a `go.work` file to facilite local development of a
+repisotry containing multile Go modules.
 Crosslink also contains functionality to remove any extra replace statements
 that are no longer required within reason (see below).
 
@@ -128,3 +130,9 @@ Can be disabled when overwriting.
 
 **Quick Tip: Make sure your `go.mod` files are tracked and committed in a VCS
 before running crosslink.**
+
+### work
+
+Creates or updates exising `go.work` file by adding use statements
+for all intra-repository Go modules. It also removes use statements
+for out-dated intra-repository Go modules.

--- a/crosslink/README.md
+++ b/crosslink/README.md
@@ -4,7 +4,7 @@ Crosslink is a tool to assist in managing go repositories that contain multiple
 intra-repository `go.mod` files. Crosslink automatically scans and inserts
 replace statements for direct and transitive intra-repository dependencies.
 Crosslink can generate a `go.work` file to facilitate local development of a
-repiository containing multiple Go modules.
+repository containing multiple Go modules.
 Crosslink also contains functionality to remove any extra replace statements
 that are no longer required within reason (see below).
 

--- a/crosslink/README.md
+++ b/crosslink/README.md
@@ -136,3 +136,11 @@ before running crosslink.**
 Creates or updates existing `go.work` file by adding use statements
 for all intra-repository Go modules. It also removes use statements
 for out-dated intra-repository Go modules.
+
+    crosslink work --root=/users/foo/multimodule-go-repo
+
+### --go
+
+ Go version applied when new `go.work` file is created (default "1.19").
+
+    crosslink work --go=1.20

--- a/crosslink/README.md
+++ b/crosslink/README.md
@@ -3,8 +3,8 @@
 Crosslink is a tool to assist in managing go repositories that contain multiple
 intra-repository `go.mod` files. Crosslink automatically scans and inserts
 replace statements for direct and transitive intra-repository dependencies.
-Crosslink can generate a `go.work` file to facilite local development of a
-repisotry containing multile Go modules.
+Crosslink can generate a `go.work` file to facilitate local development of a
+repiository containing multiple Go modules.
 Crosslink also contains functionality to remove any extra replace statements
 that are no longer required within reason (see below).
 

--- a/crosslink/README.md
+++ b/crosslink/README.md
@@ -133,6 +133,6 @@ before running crosslink.**
 
 ### work
 
-Creates or updates exising `go.work` file by adding use statements
+Creates or updates existing `go.work` file by adding use statements
 for all intra-repository Go modules. It also removes use statements
 for out-dated intra-repository Go modules.

--- a/crosslink/cmd/root.go
+++ b/crosslink/cmd/root.go
@@ -69,8 +69,8 @@ func newCommandConfig() *commandConfig {
 				return fmt.Errorf("could not create zap logger: %w", err)
 			}
 		}
-		return nil
 
+		return nil
 	}
 
 	postRunSetup := func(cmd *cobra.Command, args []string) error {

--- a/crosslink/cmd/root.go
+++ b/crosslink/cmd/root.go
@@ -135,11 +135,13 @@ func init() {
 
 	comCfg.rootCommand.PersistentFlags().StringVar(&comCfg.runConfig.RootPath, "root", "", `path to root directory of multi-module repository. If --root flag is not provided crosslink will attempt to find a
 	git repository in the current or a parent directory.`)
-	comCfg.rootCommand.PersistentFlags().StringSliceVar(&comCfg.excludeFlags, "exclude", []string{}, "list of comma separated go modules that crosslink will ignore in operations."+
-		"multiple calls of --exclude can be made")
 	comCfg.rootCommand.PersistentFlags().BoolVarP(&comCfg.runConfig.Verbose, "verbose", "v", false, "verbose output")
+	comCfg.rootCommand.Flags().StringSliceVar(&comCfg.excludeFlags, "exclude", []string{}, "list of comma separated go modules that crosslink will ignore in operations."+
+		"multiple calls of --exclude can be made")
 	comCfg.rootCommand.Flags().BoolVar(&comCfg.runConfig.Overwrite, "overwrite", false, "overwrite flag allows crosslink to make destructive (replacing or updating) actions to existing go.mod files")
-	comCfg.rootCommand.Flags().BoolVarP(&comCfg.runConfig.Prune, "prune", "p", false, "enables pruning operations on all go.mod files inside root repository")
+	comCfg.rootCommand.Flags().BoolVarP(&comCfg.runConfig.Prune, "prune", "p", false, "enables pruning operations on ll go.mod files inside root repository")
+	comCfg.pruneCommand.Flags().StringSliceVar(&comCfg.excludeFlags, "exclude", []string{}, "list of comma separated go modules that crosslink will ignore in operations."+
+		"multiple calls of --exclude can be made")
 }
 
 // transform array slice into map

--- a/crosslink/cmd/root.go
+++ b/crosslink/cmd/root.go
@@ -143,7 +143,7 @@ func init() {
 	comCfg.rootCommand.Flags().BoolVarP(&comCfg.runConfig.Prune, "prune", "p", false, "enables pruning operations on all go.mod files inside root repository")
 	comCfg.pruneCommand.Flags().StringSliceVar(&comCfg.excludeFlags, "exclude", []string{}, "list of comma separated go modules that crosslink will ignore in operations."+
 		"multiple calls of --exclude can be made")
-	comCfg.workCommand.Flags().StringVar(&comCfg.runConfig.GoVersion, "go", "1.19", "Go version applied when new go.work is created")
+	comCfg.workCommand.Flags().StringVar(&comCfg.runConfig.GoVersion, "go", "1.19", "Go version applied when new go.work file is created")
 }
 
 // transform array slice into map

--- a/crosslink/cmd/root.go
+++ b/crosslink/cmd/root.go
@@ -140,7 +140,7 @@ func init() {
 	comCfg.rootCommand.Flags().StringSliceVar(&comCfg.excludeFlags, "exclude", []string{}, "list of comma separated go modules that crosslink will ignore in operations."+
 		"multiple calls of --exclude can be made")
 	comCfg.rootCommand.Flags().BoolVar(&comCfg.runConfig.Overwrite, "overwrite", false, "overwrite flag allows crosslink to make destructive (replacing or updating) actions to existing go.mod files")
-	comCfg.rootCommand.Flags().BoolVarP(&comCfg.runConfig.Prune, "prune", "p", false, "enables pruning operations on ll go.mod files inside root repository")
+	comCfg.rootCommand.Flags().BoolVarP(&comCfg.runConfig.Prune, "prune", "p", false, "enables pruning operations on all go.mod files inside root repository")
 	comCfg.pruneCommand.Flags().StringSliceVar(&comCfg.excludeFlags, "exclude", []string{}, "list of comma separated go modules that crosslink will ignore in operations."+
 		"multiple calls of --exclude can be made")
 	comCfg.workCommand.Flags().StringVar(&comCfg.runConfig.GoVersion, "go", "1.19", "Go version applied when new go.work is created")

--- a/crosslink/cmd/root.go
+++ b/crosslink/cmd/root.go
@@ -33,6 +33,7 @@ type commandConfig struct {
 	excludeFlags []string
 	rootCommand  cobra.Command
 	pruneCommand cobra.Command
+	workCommand  cobra.Command
 }
 
 func newCommandConfig() *commandConfig {
@@ -106,13 +107,14 @@ func newCommandConfig() *commandConfig {
 	}
 	c.rootCommand.AddCommand(&c.pruneCommand)
 
-	c.rootCommand.AddCommand(&cobra.Command{
+	c.workCommand = cobra.Command{
 		Use:   "work",
 		Short: "Generate or update the go.work file with use statements for intra-repository dependencies",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return cl.Work(c.runConfig)
 		},
-	})
+	}
+	c.rootCommand.AddCommand(&c.workCommand)
 
 	return c
 }
@@ -132,7 +134,6 @@ func Execute() {
 }
 
 func init() {
-
 	comCfg.rootCommand.PersistentFlags().StringVar(&comCfg.runConfig.RootPath, "root", "", `path to root directory of multi-module repository. If --root flag is not provided crosslink will attempt to find a
 	git repository in the current or a parent directory.`)
 	comCfg.rootCommand.PersistentFlags().BoolVarP(&comCfg.runConfig.Verbose, "verbose", "v", false, "verbose output")
@@ -142,6 +143,7 @@ func init() {
 	comCfg.rootCommand.Flags().BoolVarP(&comCfg.runConfig.Prune, "prune", "p", false, "enables pruning operations on ll go.mod files inside root repository")
 	comCfg.pruneCommand.Flags().StringSliceVar(&comCfg.excludeFlags, "exclude", []string{}, "list of comma separated go modules that crosslink will ignore in operations."+
 		"multiple calls of --exclude can be made")
+	comCfg.workCommand.Flags().StringVar(&comCfg.runConfig.GoVersion, "go", "1.19", "Go version applied when new go.work is created")
 }
 
 // transform array slice into map

--- a/crosslink/cmd/root.go
+++ b/crosslink/cmd/root.go
@@ -105,6 +105,15 @@ func newCommandConfig() *commandConfig {
 		},
 	}
 	c.rootCommand.AddCommand(&c.pruneCommand)
+
+	c.rootCommand.AddCommand(&cobra.Command{
+		Use:   "work",
+		Short: "Generate or update the go.work file with use statements for intra-repository dependencies",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return cl.Work(c.runConfig)
+		},
+	})
+
 	return c
 }
 

--- a/crosslink/internal/common.go
+++ b/crosslink/internal/common.go
@@ -56,6 +56,9 @@ func writeModule(module *moduleInfo) error {
 	return nil
 }
 
+// forGoModules iterates the fn for all Go modules under rootPath.
+// The path argument of fn function is the path to the go.mod file
+// relative to rootPath (e.g. go.mod, submodule/go.mod).
 func forGoModules(logger *zap.Logger, rootPath string, fn func(path string) error) error {
 	return fs.WalkDir(os.DirFS(rootPath), ".", func(path string, dir fs.DirEntry, err error) error {
 		if err != nil {

--- a/crosslink/internal/config.go
+++ b/crosslink/internal/config.go
@@ -39,6 +39,7 @@ type RunConfig struct {
 	ExcludedPaths map[string]struct{}
 	Overwrite     bool
 	Prune         bool
+	GoVersion     string
 	Logger        *zap.Logger
 }
 

--- a/crosslink/internal/mock_test_data/testWork/go.work
+++ b/crosslink/internal/mock_test_data/testWork/go.work
@@ -1,0 +1,13 @@
+go 1.19
+
+// existing valid use statements under root should remain
+use ./testA
+
+// invalid use statements under root should be removed ONLY if prune is used
+use ./testC
+
+// use statements outside the root should remain
+use ../other-module
+
+// replace statements should remain
+replace foo.opentelemetery.io/bar => ../bar

--- a/crosslink/internal/mock_test_data/testWork/gomod
+++ b/crosslink/internal/mock_test_data/testWork/gomod
@@ -1,0 +1,3 @@
+module go.opentelemetry.io/build-tools/crosslink/testroot
+
+go 1.19

--- a/crosslink/internal/mock_test_data/testWork/testA/gomod
+++ b/crosslink/internal/mock_test_data/testWork/testA/gomod
@@ -1,0 +1,3 @@
+module go.opentelemetry.io/build-tools/crosslink/testroot/testA
+
+go 1.19

--- a/crosslink/internal/mock_test_data/testWork/testB/gomod
+++ b/crosslink/internal/mock_test_data/testWork/testB/gomod
@@ -1,0 +1,3 @@
+module go.opentelemetry.io/build-tools/crosslink/testroot/testB
+
+go 1.19

--- a/crosslink/internal/work.go
+++ b/crosslink/internal/work.go
@@ -94,7 +94,7 @@ func writeGoWork(goWork *modfile.WorkFile, rc RunConfig) error {
 	return os.WriteFile(goWorkPath, content, 0600)
 }
 
-// pruneUses removes any missing intra-repository use statements.
+// insertUses adds any missing intra-repository use statements.
 func insertUses(goWork *modfile.WorkFile, uses []string, rc RunConfig) {
 	existingGoWorkUses := make(map[string]bool, len(goWork.Use))
 	for _, use := range goWork.Use {

--- a/crosslink/internal/work.go
+++ b/crosslink/internal/work.go
@@ -1,0 +1,20 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package crosslink
+
+// Work is the main entry point for the work subcommand.
+func Work(rc RunConfig) error {
+	return nil
+}

--- a/crosslink/internal/work.go
+++ b/crosslink/internal/work.go
@@ -37,9 +37,13 @@ func Work(rc RunConfig) error {
 
 	goWork, err := openGoWork(rc)
 	if errors.Is(err, os.ErrNotExist) {
-		return nil
-	}
-	if err != nil {
+		goWork = &modfile.WorkFile{
+			Syntax: &modfile.FileSyntax{},
+		}
+		if addErr := goWork.AddGoStmt(rc.GoVersion); addErr != nil {
+			return fmt.Errorf("failed to create go.work: %w", addErr)
+		}
+	} else if err != nil {
 		return err
 	}
 

--- a/crosslink/internal/work.go
+++ b/crosslink/internal/work.go
@@ -14,7 +14,137 @@
 
 package crosslink
 
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"go.uber.org/zap"
+	"golang.org/x/mod/modfile"
+)
+
 // Work is the main entry point for the work subcommand.
 func Work(rc RunConfig) error {
-	return nil
+	rc.Logger.Debug("Crosslink run config", zap.Any("run_config", rc))
+
+	uses, err := intraRepoUses(rc.RootPath)
+	if err != nil {
+		return fmt.Errorf("failed to find Go modules: %w", err)
+	}
+
+	goWork, err := openGoWork(rc)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+
+	insertUses(goWork, uses, rc)
+	pruneUses(goWork, uses, rc)
+
+	return writeGoWork(goWork, rc)
+}
+
+func intraRepoUses(rootPath string) ([]string, error) {
+	var uses []string
+	err := fs.WalkDir(os.DirFS(rootPath), ".", func(path string, dir fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+
+		// find Go module
+		if dir.Name() != "go.mod" {
+			return nil
+		}
+
+		// normalize use statement (path)
+		use := filepath.Dir(path)
+		if use == "." {
+			use = "./"
+		} else {
+			use = "./" + use
+		}
+
+		uses = append(uses, use)
+		return nil
+	})
+	return uses, err
+}
+
+func openGoWork(rc RunConfig) (*modfile.WorkFile, error) {
+	goWorkPath := filepath.Join(rc.RootPath, "go.work")
+	content, err := os.ReadFile(filepath.Clean(goWorkPath))
+	if err != nil {
+		return nil, err
+	}
+	return modfile.ParseWork(goWorkPath, content, nil)
+}
+
+func writeGoWork(goWork *modfile.WorkFile, rc RunConfig) error {
+	goWorkPath := filepath.Join(rc.RootPath, "go.work")
+	content := modfile.Format(goWork.Syntax)
+	return os.WriteFile(goWorkPath, content, 0600)
+}
+
+// pruneUses removes any missing intra-repository use statements.
+func insertUses(goWork *modfile.WorkFile, uses []string, rc RunConfig) {
+	existingGoWorkUses := make(map[string]bool, len(goWork.Use))
+	for _, use := range goWork.Use {
+		existingGoWorkUses[use.Path] = true
+	}
+
+	for _, useToAdd := range uses {
+		if existingGoWorkUses[useToAdd] {
+			continue
+		}
+		err := goWork.AddUse(useToAdd, "")
+		if err != nil {
+			rc.Logger.Error("Failed to add use statement", zap.Error(err),
+				zap.String("path", useToAdd))
+		}
+	}
+}
+
+// pruneUses removes any extraneous intra-repository use statements.
+func pruneUses(goWork *modfile.WorkFile, uses []string, rc RunConfig) {
+	requiredUses := make(map[string]bool, len(uses))
+	for _, use := range uses {
+		requiredUses[use] = true
+	}
+
+	usesToKeep := make(map[string]bool, len(goWork.Use))
+	for _, use := range goWork.Use {
+		usesToKeep[use.Path] = true
+	}
+
+	for use := range usesToKeep {
+		// check to see if its intra dependency
+		if !strings.HasPrefix(use, "./") {
+			continue
+		}
+
+		// check if the intra dependency is still used
+		if requiredUses[use] {
+			continue
+		}
+
+		usesToKeep[use] = false
+	}
+
+	// remove unnecessary uses
+	for use, needed := range usesToKeep {
+		if needed {
+			continue
+		}
+
+		err := goWork.DropUse(use)
+		if err != nil {
+			rc.Logger.Error("Failed to drop use statement", zap.Error(err),
+				zap.String("path", use))
+		}
+	}
 }

--- a/crosslink/internal/work_test.go
+++ b/crosslink/internal/work_test.go
@@ -55,30 +55,31 @@ func TestWork(t *testing.T) {
 			// replace statements should remain
 			replace foo.opentelemetery.io/bar => ../bar`,
 		},
-		{
-			testName: "excluded",
-			config: RunConfig{Logger: lg, ExcludedPaths: map[string]struct{}{
-				"go.opentelemetry.io/build-tools/crosslink/testroot/testB": {},
-				"go.opentelemetry.io/build-tools/crosslink/testroot/testC": {},
-			}},
-			expected: `go 1.19
-			// new statement added by crosslink
-			use ./
-			// existing valid use statements under root should remain
-			use ./testA
+		// excluded flag is NOT supported
+		// {
+		// 	testName: "excluded",
+		// 	config: RunConfig{Logger: lg, ExcludedPaths: map[string]struct{}{
+		// 		"go.opentelemetry.io/build-tools/crosslink/testroot/testB": {},
+		// 		"go.opentelemetry.io/build-tools/crosslink/testroot/testC": {},
+		// 	}},
+		// 	expected: `go 1.19
+		// 	// new statement added by crosslink
+		// 	use ./
+		// 	// existing valid use statements under root should remain
+		// 	use ./testA
 
-			// do not add EXCLUDED modules
-			// use ./testB
-			
-			// do not add remove EXCLUDED modules
-			use ./testC
-			
-			// use statements outside the root should remain
-			use ../other-module
-			
-			// replace statements should remain
-			replace foo.opentelemetery.io/bar => ../bar`,
-		},
+		// 	// do not add EXCLUDED modules
+		// 	// use ./testB
+
+		// 	// do not add remove EXCLUDED modules
+		// 	use ./testC
+
+		// 	// use statements outside the root should remain
+		// 	use ../other-module
+
+		// 	// replace statements should remain
+		// 	replace foo.opentelemetery.io/bar => ../bar`,
+		// },
 	}
 
 	for _, test := range tests {

--- a/crosslink/internal/work_test.go
+++ b/crosslink/internal/work_test.go
@@ -32,22 +32,22 @@ func TestWorkUpdate(t *testing.T) {
 
 	mockDir := "testWork"
 	want := `go 1.19
-			// new statement added by crosslink
-			use ./
-			// existing valid use statements under root should remain
-			use ./testA
-		
-			// new statement added by crossling
-			use ./testB
-			
-			// invalid use statements under root should be removed
-			// use ./testC
-			
-			// use statements outside the root should remain
-			use ../other-module
-			
-			// replace statements should remain
-			replace foo.opentelemetery.io/bar => ../bar`
+// new statement added by crosslink
+use ./
+// existing valid use statements under root should remain
+use ./testA
+
+// new statement added by crossling
+use ./testB
+
+// invalid use statements under root should be removed
+// use ./testC
+
+// use statements outside the root should remain
+use ../other-module
+
+// replace statements should remain
+replace foo.opentelemetery.io/bar => ../bar`
 
 	tmpRootDir, err := createTempTestDir(mockDir)
 	if err != nil {
@@ -73,9 +73,9 @@ func TestWorkNew(t *testing.T) {
 
 	mockDir := "testWork"
 	want := `go 1.20
-			use ./
-			use ./testA
-			use ./testB`
+use ./
+use ./testA
+use ./testB`
 
 	tmpRootDir, err := createTempTestDir(mockDir)
 	if err != nil {

--- a/crosslink/internal/work_test.go
+++ b/crosslink/internal/work_test.go
@@ -37,7 +37,7 @@ use ./
 // existing valid use statements under root should remain
 use ./testA
 
-// new statement added by crossling
+// new statement added by crosslink
 use ./testB
 
 // invalid use statements under root should be removed

--- a/crosslink/internal/work_test.go
+++ b/crosslink/internal/work_test.go
@@ -1,0 +1,152 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package crosslink
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"golang.org/x/mod/modfile"
+)
+
+func TestWork(t *testing.T) {
+	lg, _ := zap.NewDevelopment()
+
+	tests := []struct {
+		testName string
+		config   RunConfig
+		expected string
+	}{
+		{
+			testName: "default",
+			config:   RunConfig{Logger: lg},
+			expected: `go 1.19
+			// new statement added by crosslink
+			use ./
+			// existing valid use statements under root should remain
+			use ./testA
+		
+			// new statement added by crossling
+			use ./testB
+			
+			// invalid use statements under root should be removed ONLY if prune is used
+			use ./testC
+			
+			// use statements outside the root should remain
+			use ../other-module
+			
+			// replace statements should remain
+			replace foo.opentelemetery.io/bar => ../bar`,
+		},
+		{
+			testName: "prune",
+			config:   RunConfig{Logger: lg, Prune: true},
+			expected: `go 1.19
+			// new statement added by crosslink
+			use ./
+			// existing valid use statements under root should remain
+			use ./testA
+			// new statement added by crosslink
+			use ./testB
+			
+			// invalid use statements under root is REMOVED when prune is used
+			// use ./testC
+			
+			// use statements outside the root should remain
+			use ../other-module
+			
+			// replace statements should remain
+			replace foo.opentelemetery.io/bar => ../bar`,
+		},
+		{
+			testName: "excluded",
+			config: RunConfig{Logger: lg, ExcludedPaths: map[string]struct{}{
+				"go.opentelemetry.io/build-tools/crosslink/testroot/testB": {},
+			}},
+			expected: `go 1.19
+			// new statement added by crosslink
+			use ./
+			// existing valid use statements under root should remain
+			use ./testA
+			// do not add EXCLUDED modules
+			// use ./testB
+			
+			// invalid use statements under root should be removed ONLY if prune is used
+			use ./testC
+			
+			// use statements outside the root should remain
+			use ../other-module
+			
+			// replace statements should remain
+			replace foo.opentelemetery.io/bar => ../bar`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.testName, func(t *testing.T) {
+			mockDir := "testWork"
+			tmpRootDir, err := createTempTestDir(mockDir)
+			if err != nil {
+				t.Fatal("creating temp dir:", err)
+			}
+
+			err = renameGoMod(tmpRootDir)
+			if err != nil {
+				t.Errorf("error renaming gomod files: %v", err)
+			}
+			t.Cleanup(func() { os.RemoveAll(tmpRootDir) })
+
+			test.config.RootPath = tmpRootDir
+
+			err = Work(test.config)
+			require.NoError(t, err)
+			goWorkContent, err := os.ReadFile(filepath.Clean(filepath.Join(tmpRootDir, "go.work")))
+			require.NoError(t, err)
+
+			actual, err := modfile.ParseWork("go.work", goWorkContent, nil)
+			require.NoError(t, err)
+			actual.Cleanup()
+
+			expected, err := modfile.ParseWork("go.work", []byte(test.expected), nil)
+			require.NoError(t, err)
+			expected.Cleanup()
+
+			// replace structs need to be assorted to avoid flaky fails in test
+			replaceSortFunc := func(x, y *modfile.Replace) bool {
+				return x.Old.Path < y.Old.Path
+			}
+
+			// use structs need to be assorted to avoid flaky fails in test
+			useSortFunc := func(x, y *modfile.Use) bool {
+				return x.Path < y.Path
+			}
+
+			if diff := cmp.Diff(expected, actual,
+				cmpopts.IgnoreFields(modfile.Use{}, "Syntax", "ModulePath"),
+				cmpopts.IgnoreFields(modfile.Replace{}, "Syntax"),
+				cmpopts.IgnoreFields(modfile.WorkFile{}, "Syntax"),
+				cmpopts.SortSlices(replaceSortFunc),
+				cmpopts.SortSlices(useSortFunc),
+			); diff != "" {
+				t.Errorf("go.work mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/crosslink/internal/work_test.go
+++ b/crosslink/internal/work_test.go
@@ -46,27 +46,7 @@ func TestWork(t *testing.T) {
 			// new statement added by crossling
 			use ./testB
 			
-			// invalid use statements under root should be removed ONLY if prune is used
-			use ./testC
-			
-			// use statements outside the root should remain
-			use ../other-module
-			
-			// replace statements should remain
-			replace foo.opentelemetery.io/bar => ../bar`,
-		},
-		{
-			testName: "prune",
-			config:   RunConfig{Logger: lg, Prune: true},
-			expected: `go 1.19
-			// new statement added by crosslink
-			use ./
-			// existing valid use statements under root should remain
-			use ./testA
-			// new statement added by crosslink
-			use ./testB
-			
-			// invalid use statements under root is REMOVED when prune is used
+			// invalid use statements under root should be removed
 			// use ./testC
 			
 			// use statements outside the root should remain
@@ -79,16 +59,18 @@ func TestWork(t *testing.T) {
 			testName: "excluded",
 			config: RunConfig{Logger: lg, ExcludedPaths: map[string]struct{}{
 				"go.opentelemetry.io/build-tools/crosslink/testroot/testB": {},
+				"go.opentelemetry.io/build-tools/crosslink/testroot/testC": {},
 			}},
 			expected: `go 1.19
 			// new statement added by crosslink
 			use ./
 			// existing valid use statements under root should remain
 			use ./testA
+
 			// do not add EXCLUDED modules
 			// use ./testB
 			
-			// invalid use statements under root should be removed ONLY if prune is used
+			// do not add remove EXCLUDED modules
 			use ./testC
 			
 			// use statements outside the root should remain


### PR DESCRIPTION
## Why

Fixes https://github.com/open-telemetry/opentelemetry-go-build-tools/issues/309

Towards https://github.com/open-telemetry/opentelemetry-go/issues/3964

`go.work` is honored by `gopls` language server so that develoeprs get better UX in tools like VSCode, Vim, Emacs etc

References:
- https://go.dev/ref/mod#workspaces
- https://go.dev/blog/get-familiar-with-workspaces
- https://go.dev/doc/tutorial/workspaces

Prior work: https://github.com/open-telemetry/opentelemetry-go-build-tools/pull/308

## What

Make `crosslink` to create/update the `use` in `go.work` file (if it exists).

Take notice that it will not harm any repositories which do not use Go workspaces. However developers could still use the functionality during development 😉 

## Testing

```sh
make gowork
```

created following `go.work` file

```
go 1.19

use (
	./checkdoc
	./chloggen
	./crosslink
	./dbotconf
	./
	./gotmpl
	./internal/tools
	./issuegenerator
	./multimod
	./semconvgen
)
```


