### PR TITLE
Include /gotmpl in .github/dependabot.yml

### DIFF
--- a/.chloggen/dbotconf-gen-gotmpl.yaml
+++ b/.chloggen/dbotconf-gen-gotmpl.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. crosslink)
+component: gotmpl
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Update dependabot config for gotmpl
+
+# One or more tracking issues related to the change
+issues: [280]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -56,6 +56,15 @@ updates:
       interval: weekly
       day: sunday
   - package-ecosystem: gomod
+    directory: /gotmpl
+    labels:
+      - dependencies
+      - go
+      - Skip Changelog
+    schedule:
+      interval: weekly
+      day: sunday
+  - package-ecosystem: gomod
     directory: /internal/tools
     labels:
       - dependencies


### PR DESCRIPTION
This will configure dependabot to update the dependencies for the gotmpl module. It seems like it's already being updated since https://github.com/open-telemetry/opentelemetry-go-build-tools/pull/319 updated it recently. Though, I'm explicitly adding it here to ensure that it gets updated.

cc: @pellared 