### PR TITLE
[chloggen] Add new change_type value for library API changes

### DIFF
--- a/.chloggen/mx-psi_library-api-change.yaml
+++ b/.chloggen/mx-psi_library-api-change.yaml
@@ -8,7 +8,7 @@ component: chloggen
 note: Add new 'library_api_change' change_type value.
 
 # One or more tracking issues related to the change
-issues: []
+issues: [360]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/.chloggen/mx-psi_library-api-change.yaml
+++ b/.chloggen/mx-psi_library-api-change.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. crosslink)
+component: chloggen
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add new 'library_api_change' change_type value.
+
+# One or more tracking issues related to the change
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: This is a value specific to the OpenTelemetry Collector Contrib repository to indicate API only changes

--- a/chloggen/internal/chlog/entry.go
+++ b/chloggen/internal/chlog/entry.go
@@ -24,11 +24,12 @@ import (
 )
 
 const (
-	Breaking     = "breaking"
-	Deprecation  = "deprecation"
-	NewComponent = "new_component"
-	Enhancement  = "enhancement"
-	BugFix       = "bug_fix"
+	Breaking         = "breaking"
+	Deprecation      = "deprecation"
+	NewComponent     = "new_component"
+	Enhancement      = "enhancement"
+	BugFix           = "bug_fix"
+	LibraryAPIChange = "library_api_change"
 )
 
 type Entry struct {

--- a/chloggen/internal/chlog/summary.go
+++ b/chloggen/internal/chlog/summary.go
@@ -32,6 +32,7 @@ type summary struct {
 	NewComponents   []string
 	Enhancements    []string
 	BugFixes        []string
+	LibraryChanges  []string
 }
 
 func GenerateSummary(version string, entries []*Entry) (string, error) {
@@ -51,6 +52,8 @@ func GenerateSummary(version string, entries []*Entry) (string, error) {
 			s.Enhancements = append(s.Enhancements, entry.String())
 		case BugFix:
 			s.BugFixes = append(s.BugFixes, entry.String())
+		case LibraryAPIChange:
+			s.LibraryChanges = append(s.LibraryChanges, entry.String())
 		}
 	}
 
@@ -59,6 +62,7 @@ func GenerateSummary(version string, entries []*Entry) (string, error) {
 	s.NewComponents = sort.StringSlice(s.NewComponents)
 	s.Enhancements = sort.StringSlice(s.Enhancements)
 	s.BugFixes = sort.StringSlice(s.BugFixes)
+	s.LibraryChanges = sort.StringSlice(s.LibraryChanges)
 
 	return s.String()
 }

--- a/chloggen/internal/chlog/summary.tmpl
+++ b/chloggen/internal/chlog/summary.tmpl
@@ -55,3 +55,13 @@
 {{ $change }}
 {{- end }}
 {{- end }}
+{{- if .LibraryChanges }}
+
+### 🛠️ Library changes 🛠️
+
+{{- range $i, $change := .LibraryChanges }}
+{{- if eq $i 0}}
+{{end}}
+{{ $change }}
+{{- end }}
+{{- end }}

--- a/chloggen/internal/chlog/summary_test.go
+++ b/chloggen/internal/chlog/summary_test.go
@@ -57,3 +57,46 @@ bar
 foobar
 `, result)
 }
+
+func Test_SummaryStringWithLibraryChanges(t *testing.T) {
+	s := summary{
+		Version:         "1.0",
+		BreakingChanges: []string{"foo", "bar"},
+		Deprecations:    []string{"foo", "bar"},
+		NewComponents:   []string{"foo", "bar", "new component"},
+		Enhancements:    []string{},
+		BugFixes:        []string{"foo", "bar", "foobar"},
+		LibraryChanges:  []string{"foo"},
+	}
+	result, err := s.String()
+	assert.NoError(t, err)
+	assert.Equal(t, `
+## 1.0
+
+### 🛑 Breaking changes 🛑
+
+foo
+bar
+
+### 🚩 Deprecations 🚩
+
+foo
+bar
+
+### 🚀 New components 🚀
+
+foo
+bar
+new component
+
+### 🧰 Bug fixes 🧰
+
+foo
+bar
+foobar
+
+### 🛠️ Library changes 🛠️
+
+foo
+`, result)
+}


### PR DESCRIPTION
Updates open-telemetry/opentelemetry-collector-contrib/issues/24014.

This adds a new `library_api_change` type that would apply to Go API only changes in the OpenTelemetry Collector contrib repository (e.g. those related to open-telemetry/opentelemetry-collector-contrib/issues/17273).