### PR TITLE
[chore][chloggen] Rename 'Context' to 'Config' and move to dedicated package

### DIFF
--- a/chloggen/cmd/cmd_test.go
+++ b/chloggen/cmd/cmd_test.go
@@ -27,6 +27,7 @@ import (
 	"gopkg.in/yaml.v3"
 
 	"go.opentelemetry.io/build-tools/chloggen/internal/chlog"
+	"go.opentelemetry.io/build-tools/chloggen/internal/config"
 )
 
 func getSampleEntries() []*chlog.Entry {
@@ -97,18 +98,18 @@ func entryWithSubtext() *chlog.Entry {
 	}
 }
 
-func setupTestDir(t *testing.T, entries []*chlog.Entry) chlog.Context {
-	ctx := chlog.New(t.TempDir())
+func setupTestDir(t *testing.T, entries []*chlog.Entry) config.Config {
+	ctx := config.New(t.TempDir())
 
 	// Create a known dummy changelog which may be updated by the test
-	changelogBytes, err := os.ReadFile(filepath.Join("testdata", chlog.DefaultChangelogMD))
+	changelogBytes, err := os.ReadFile(filepath.Join("testdata", config.DefaultChangelogMD))
 	require.NoError(t, err)
 	require.NoError(t, os.WriteFile(ctx.ChangelogMD, changelogBytes, os.FileMode(0755)))
 
 	require.NoError(t, os.Mkdir(ctx.ChloggenDir, os.FileMode(0755)))
 
 	// Copy the entry template, for tests that ensure it is not deleted
-	templateInRootDir := chlog.New("testdata").TemplateYAML
+	templateInRootDir := config.New("testdata").TemplateYAML
 	templateBytes, err := os.ReadFile(filepath.Clean(templateInRootDir))
 	require.NoError(t, err)
 	require.NoError(t, os.WriteFile(ctx.TemplateYAML, templateBytes, os.FileMode(0755)))
@@ -120,7 +121,7 @@ func setupTestDir(t *testing.T, entries []*chlog.Entry) chlog.Context {
 	return ctx
 }
 
-func writeEntryYAML(ctx chlog.Context, filename string, entry *chlog.Entry) error {
+func writeEntryYAML(ctx config.Config, filename string, entry *chlog.Entry) error {
 	entryBytes, err := yaml.Marshal(entry)
 	if err != nil {
 		return err

--- a/chloggen/cmd/new.go
+++ b/chloggen/cmd/new.go
@@ -31,7 +31,7 @@ func newCmd() *cobra.Command {
 		Use:   "new",
 		Short: "Creates new change file",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			path := filepath.Join(chlogCtx.ChloggenDir, cleanFileName(filename))
+			path := filepath.Join(globalCfg.ChloggenDir, cleanFileName(filename))
 			var pathWithExt string
 			switch ext := filepath.Ext(path); ext {
 			case ".yaml":
@@ -42,7 +42,7 @@ func newCmd() *cobra.Command {
 				pathWithExt = path + ".yaml"
 			}
 
-			templateBytes, err := os.ReadFile(filepath.Clean(chlogCtx.TemplateYAML))
+			templateBytes, err := os.ReadFile(filepath.Clean(globalCfg.TemplateYAML))
 			if err != nil {
 				return err
 			}

--- a/chloggen/cmd/new_test.go
+++ b/chloggen/cmd/new_test.go
@@ -34,7 +34,7 @@ Flags:
 Global Flags:
       --chloggen-directory string   directory containing unreleased change log entries (default: .chloggen)`
 
-func TestNewCommand(t *testing.T) {
+func TestNewErr(t *testing.T) {
 	var out, err string
 
 	out, err = runCobra(t, "new", "--help")
@@ -48,32 +48,35 @@ func TestNewCommand(t *testing.T) {
 	out, err = runCobra(t, "new", "--filename", "my-change")
 	assert.Contains(t, out, newUsage)
 	assert.Contains(t, err, `no such file or directory`)
+}
 
-	// Set up a test directory to which we will write new files
-	chlogCtx = setupTestDir(t, []*chlog.Entry{})
+func TestNew(t *testing.T) {
+	globalCfg = setupTestDir(t, []*chlog.Entry{})
+
+	var out, err string
 
 	out, err = runCobra(t, "new", "--filename", "my-change")
-	assert.Contains(t, out, fmt.Sprintf("Changelog entry template copied to: %s", filepath.Join(chlogCtx.ChloggenDir, "my-change.yaml")))
+	assert.Contains(t, out, fmt.Sprintf("Changelog entry template copied to: %s", filepath.Join(globalCfg.ChloggenDir, "my-change.yaml")))
 	assert.Empty(t, err)
 
 	out, err = runCobra(t, "new", "--filename", "some-change.yaml")
-	assert.Contains(t, out, fmt.Sprintf("Changelog entry template copied to: %s", filepath.Join(chlogCtx.ChloggenDir, "some-change.yaml")))
+	assert.Contains(t, out, fmt.Sprintf("Changelog entry template copied to: %s", filepath.Join(globalCfg.ChloggenDir, "some-change.yaml")))
 	assert.Empty(t, err)
 
 	out, err = runCobra(t, "new", "--filename", "some-change.yml")
-	assert.Contains(t, out, fmt.Sprintf("Changelog entry template copied to: %s", filepath.Join(chlogCtx.ChloggenDir, "some-change.yaml")))
+	assert.Contains(t, out, fmt.Sprintf("Changelog entry template copied to: %s", filepath.Join(globalCfg.ChloggenDir, "some-change.yaml")))
 	assert.Empty(t, err)
 
 	out, err = runCobra(t, "new", "--filename", "replace/forward/slash")
-	assert.Contains(t, out, fmt.Sprintf("Changelog entry template copied to: %s", filepath.Join(chlogCtx.ChloggenDir, "replace_forward_slash.yaml")))
+	assert.Contains(t, out, fmt.Sprintf("Changelog entry template copied to: %s", filepath.Join(globalCfg.ChloggenDir, "replace_forward_slash.yaml")))
 	assert.Empty(t, err)
 
 	out, err = runCobra(t, "new", "--filename", "not.an.extension")
-	assert.Contains(t, out, fmt.Sprintf("Changelog entry template copied to: %s", filepath.Join(chlogCtx.ChloggenDir, "not.an.extension.yaml")))
+	assert.Contains(t, out, fmt.Sprintf("Changelog entry template copied to: %s", filepath.Join(globalCfg.ChloggenDir, "not.an.extension.yaml")))
 	assert.Empty(t, err)
 
 	out, err = runCobra(t, "new", "--filename", "my-change.txt")
-	assert.Contains(t, out, fmt.Sprintf("Changelog entry template copied to: %s", filepath.Join(chlogCtx.ChloggenDir, "my-change.txt.yaml")))
+	assert.Contains(t, out, fmt.Sprintf("Changelog entry template copied to: %s", filepath.Join(globalCfg.ChloggenDir, "my-change.txt.yaml")))
 	assert.Empty(t, err)
 }
 

--- a/chloggen/cmd/root.go
+++ b/chloggen/cmd/root.go
@@ -15,14 +15,17 @@
 package cmd
 
 import (
+	"fmt"
+	"os"
+
 	"github.com/spf13/cobra"
 
-	"go.opentelemetry.io/build-tools/chloggen/internal/chlog"
+	"go.opentelemetry.io/build-tools/chloggen/internal/config"
 )
 
 var (
 	chloggenDir string
-	chlogCtx    chlog.Context
+	globalCfg   config.Config
 )
 
 func rootCmd() *cobra.Command {
@@ -48,13 +51,22 @@ func init() {
 
 func initConfig() {
 	// Don't override if already set in tests
-	var uninitialized chlog.Context
-	if chlogCtx != uninitialized {
+	var uninitialized config.Config
+	if globalCfg != uninitialized {
 		return
 	}
 
 	if chloggenDir == "" {
 		chloggenDir = ".chloggen"
 	}
-	chlogCtx = chlog.New(chlog.RepoRoot(), chlog.WithChloggenDir(chloggenDir))
+	globalCfg = config.New(repoRoot(), config.WithChloggenDir(chloggenDir))
+}
+
+func repoRoot() string {
+	dir, err := os.Getwd()
+	if err != nil {
+		// This is not expected, but just in case
+		fmt.Println("FAIL: Could not determine current working directory")
+	}
+	return dir
 }

--- a/chloggen/cmd/root_test.go
+++ b/chloggen/cmd/root_test.go
@@ -38,7 +38,7 @@ Flags:
 
 Use "chloggen [command] --help" for more information about a command.`
 
-func TestRootCommand(t *testing.T) {
+func TestRoot(t *testing.T) {
 	var out, err string
 
 	out, err = runCobra(t)
@@ -48,4 +48,8 @@ func TestRootCommand(t *testing.T) {
 	out, err = runCobra(t, "--help")
 	assert.Contains(t, out, rootUsage)
 	assert.Empty(t, err)
+}
+
+func TestRepoRoot(t *testing.T) {
+	assert.DirExists(t, repoRoot())
 }

--- a/chloggen/cmd/update.go
+++ b/chloggen/cmd/update.go
@@ -40,7 +40,7 @@ func updateCmd() *cobra.Command {
 		Use:   "update",
 		Short: "Updates CHANGELOG.MD to include all new changes",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			entries, err := chlog.ReadEntries(chlogCtx)
+			entries, err := chlog.ReadEntries(globalCfg)
 			if err != nil {
 				return err
 			}
@@ -60,7 +60,7 @@ func updateCmd() *cobra.Command {
 				return nil
 			}
 
-			oldChlogBytes, err := os.ReadFile(filepath.Clean(chlogCtx.ChangelogMD))
+			oldChlogBytes, err := os.ReadFile(filepath.Clean(globalCfg.ChangelogMD))
 			if err != nil {
 				return err
 			}
@@ -77,18 +77,18 @@ func updateCmd() *cobra.Command {
 			chlogBuilder.WriteString(chlogUpdate)
 			chlogBuilder.WriteString(chlogHistory)
 
-			tmpMD := chlogCtx.ChangelogMD + ".tmp"
+			tmpMD := globalCfg.ChangelogMD + ".tmp"
 			if err = os.WriteFile(filepath.Clean(tmpMD), []byte(chlogBuilder.String()), 0600); err != nil {
 				return err
 			}
 
-			if err = os.Rename(tmpMD, chlogCtx.ChangelogMD); err != nil {
+			if err = os.Rename(tmpMD, globalCfg.ChangelogMD); err != nil {
 				return err
 			}
 
-			cmd.Printf("Finished updating %s\n", chlogCtx.ChangelogMD)
+			cmd.Printf("Finished updating %s\n", globalCfg.ChangelogMD)
 
-			return chlog.DeleteEntries(chlogCtx)
+			return chlog.DeleteEntries(globalCfg)
 		},
 	}
 	cmd.Flags().StringVarP(&version, "version", "v", "vTODO", "will be rendered directly into the update text")

--- a/chloggen/cmd/validate.go
+++ b/chloggen/cmd/validate.go
@@ -27,11 +27,11 @@ func validateCmd() *cobra.Command {
 		Use:   "validate",
 		Short: "Validates the files in the changelog directory",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if _, err := os.Stat(chlogCtx.ChloggenDir); err != nil {
+			if _, err := os.Stat(globalCfg.ChloggenDir); err != nil {
 				return err
 			}
 
-			entries, err := chlog.ReadEntries(chlogCtx)
+			entries, err := chlog.ReadEntries(globalCfg)
 			if err != nil {
 				return err
 			}
@@ -40,7 +40,7 @@ func validateCmd() *cobra.Command {
 					return err
 				}
 			}
-			cmd.Printf("PASS: all files in %s/ are valid\n", chlogCtx.ChloggenDir)
+			cmd.Printf("PASS: all files in %s/ are valid\n", globalCfg.ChloggenDir)
 			return nil
 		},
 	}

--- a/chloggen/cmd/validate_test.go
+++ b/chloggen/cmd/validate_test.go
@@ -23,7 +23,28 @@ import (
 	"go.opentelemetry.io/build-tools/chloggen/internal/chlog"
 )
 
-func TestValidateE2E(t *testing.T) {
+const validateUsage = `Usage:
+  chloggen validate [flags]
+
+Flags:
+  -h, --help   help for validate
+
+Global Flags:
+      --chloggen-directory string   directory containing unreleased change log entries (default: .chloggen)`
+
+func TestValidateErr(t *testing.T) {
+	var out, err string
+
+	out, err = runCobra(t, "validate", "--help")
+	assert.Contains(t, out, validateUsage)
+	assert.Empty(t, err)
+
+	out, err = runCobra(t, "validate")
+	assert.Contains(t, out, validateUsage)
+	assert.Contains(t, err, "no such file or directory")
+}
+
+func TestValidate(t *testing.T) {
 	tests := []struct {
 		name    string
 		entries []*chlog.Entry
@@ -119,7 +140,7 @@ func TestValidateE2E(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			chlogCtx = setupTestDir(t, tc.entries)
+			globalCfg = setupTestDir(t, tc.entries)
 
 			out, err := runCobra(t, "validate")
 
@@ -127,7 +148,7 @@ func TestValidateE2E(t *testing.T) {
 				assert.Regexp(t, tc.wantErr, err)
 			} else {
 				assert.Empty(t, err)
-				assert.Contains(t, out, fmt.Sprintf("PASS: all files in %s/ are valid", chlogCtx.ChloggenDir))
+				assert.Contains(t, out, fmt.Sprintf("PASS: all files in %s/ are valid", globalCfg.ChloggenDir))
 			}
 		})
 	}

--- a/chloggen/internal/chlog/entry.go
+++ b/chloggen/internal/chlog/entry.go
@@ -21,6 +21,8 @@ import (
 	"strings"
 
 	"gopkg.in/yaml.v3"
+
+	"go.opentelemetry.io/build-tools/chloggen/internal/config"
 )
 
 const (
@@ -91,15 +93,15 @@ func (e Entry) String() string {
 	return sb.String()
 }
 
-func ReadEntries(ctx Context) ([]*Entry, error) {
-	entryYAMLs, err := filepath.Glob(filepath.Join(ctx.ChloggenDir, "*.yaml"))
+func ReadEntries(cfg config.Config) ([]*Entry, error) {
+	entryYAMLs, err := filepath.Glob(filepath.Join(cfg.ChloggenDir, "*.yaml"))
 	if err != nil {
 		return nil, err
 	}
 
 	entries := make([]*Entry, 0, len(entryYAMLs))
 	for _, entryYAML := range entryYAMLs {
-		if filepath.Base(entryYAML) == filepath.Base(ctx.TemplateYAML) {
+		if filepath.Base(entryYAML) == filepath.Base(cfg.TemplateYAML) {
 			continue
 		}
 
@@ -117,14 +119,14 @@ func ReadEntries(ctx Context) ([]*Entry, error) {
 	return entries, nil
 }
 
-func DeleteEntries(ctx Context) error {
-	entryYAMLs, err := filepath.Glob(filepath.Join(ctx.ChloggenDir, "*.yaml"))
+func DeleteEntries(cfg config.Config) error {
+	entryYAMLs, err := filepath.Glob(filepath.Join(cfg.ChloggenDir, "*.yaml"))
 	if err != nil {
 		return err
 	}
 
 	for _, entryYAML := range entryYAMLs {
-		if filepath.Base(entryYAML) == filepath.Base(ctx.TemplateYAML) {
+		if filepath.Base(entryYAML) == filepath.Base(cfg.TemplateYAML) {
 			continue
 		}
 

--- a/chloggen/internal/chlog/entry_test.go
+++ b/chloggen/internal/chlog/entry_test.go
@@ -22,6 +22,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v3"
+
+	"go.opentelemetry.io/build-tools/chloggen/internal/config"
 )
 
 func TestEntry(t *testing.T) {
@@ -117,7 +119,7 @@ func TestEntry(t *testing.T) {
 
 func TestReadDeleteEntries(t *testing.T) {
 	tempDir := t.TempDir()
-	entriesDir := filepath.Join(tempDir, DefaultChloggenDir)
+	entriesDir := filepath.Join(tempDir, config.DefaultChloggenDir)
 	require.NoError(t, os.Mkdir(entriesDir, os.ModePerm))
 
 	entryA := Entry{
@@ -155,14 +157,14 @@ func TestReadDeleteEntries(t *testing.T) {
 	_, err = fileB.Write(bytesB)
 	require.NoError(t, err)
 
-	chloggenCtx := New(tempDir)
-	entries, err := ReadEntries(chloggenCtx)
+	cfg := config.New(tempDir)
+	entries, err := ReadEntries(cfg)
 	assert.NoError(t, err)
 
 	assert.ElementsMatch(t, []*Entry{&entryA, &entryB}, entries)
 
-	assert.NoError(t, DeleteEntries(chloggenCtx))
-	entries, err = ReadEntries(chloggenCtx)
+	assert.NoError(t, DeleteEntries(cfg))
+	entries, err = ReadEntries(cfg)
 	assert.NoError(t, err)
 	assert.Empty(t, entries)
 }

--- a/chloggen/internal/config/config.go
+++ b/chloggen/internal/config/config.go
@@ -12,11 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package chlog
+package config
 
 import (
-	"fmt"
-	"os"
 	"path/filepath"
 )
 
@@ -26,25 +24,25 @@ const (
 	DefaultTemplateYAML = "TEMPLATE.yaml"
 )
 
-// Context enables tests by allowing them to work in an test directory
-type Context struct {
+// Config enables tests by allowing them to work in an test directory
+type Config struct {
 	rootDir      string
 	ChangelogMD  string
 	ChloggenDir  string
 	TemplateYAML string
 }
 
-type Option func(*Context)
+type Option func(*Config)
 
 func WithChloggenDir(chloggenDir string) Option {
-	return func(ctx *Context) {
+	return func(ctx *Config) {
 		ctx.ChloggenDir = filepath.Join(ctx.rootDir, chloggenDir)
 		ctx.TemplateYAML = filepath.Join(ctx.rootDir, chloggenDir, DefaultTemplateYAML)
 	}
 }
 
-func New(rootDir string, options ...Option) Context {
-	ctx := Context{
+func New(rootDir string, options ...Option) Config {
+	ctx := Config{
 		rootDir:      rootDir,
 		ChangelogMD:  filepath.Join(rootDir, DefaultChangelogMD),
 		ChloggenDir:  filepath.Join(rootDir, DefaultChloggenDir),
@@ -54,13 +52,4 @@ func New(rootDir string, options ...Option) Context {
 		op(&ctx)
 	}
 	return ctx
-}
-
-func RepoRoot() string {
-	dir, err := os.Getwd()
-	if err != nil {
-		// This is not expected, but just in case
-		fmt.Println("FAIL: Could not determine current working directory")
-	}
-	return dir
 }

--- a/chloggen/internal/config/config_test.go
+++ b/chloggen/internal/config/config_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package chlog
+package config
 
 import (
 	"path/filepath"
@@ -38,8 +38,4 @@ func TestWithChloggenDir(t *testing.T) {
 	assert.Equal(t, filepath.Join(root, chloggenDir), ctx.ChloggenDir)
 	assert.Equal(t, filepath.Join(root, DefaultChangelogMD), ctx.ChangelogMD)
 	assert.Equal(t, filepath.Join(root, chloggenDir, DefaultTemplateYAML), ctx.TemplateYAML)
-}
-
-func TestRepoRoot(t *testing.T) {
-	assert.DirExists(t, RepoRoot())
 }


### PR DESCRIPTION
This PR follows #368 and #369 to further prepare the chloggen tool for the introduction of a repo-level configuration file.
- Rebrands the notion of a "Context" as a "Config", but stops short of actually introducing the config file.
- Creates a `chloggen/internal/config` package and moves former "Context" files into this package. 
- Moves `RepoRoot` to `cmd.repoRoot`. The function is related to the "Context" of the tool, but as a "Config", it makes more sense that the value is provided.
- Further normalize tests across sub functions.