### PR TITLE
[chloggen] Introduce repo-level config file

### DIFF
--- a/.chloggen/chloggen-config-file-2.yaml
+++ b/.chloggen/chloggen-config-file-2.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. crosslink)
+component: chloggen
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Adds a 'config' flag and option to configure chloggen with a config file.
+
+# One or more tracking issues related to the change
+issues: [371]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/.chloggen/chloggen-config-file.yaml
+++ b/.chloggen/chloggen-config-file.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. crosslink)
+component: chloggen
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Remove 'chloggen-directory' flag. Use config file instead.
+
+# One or more tracking issues related to the change
+issues: [371]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/chloggen/cmd/cmd_test.go
+++ b/chloggen/cmd/cmd_test.go
@@ -99,34 +99,34 @@ func entryWithSubtext() *chlog.Entry {
 }
 
 func setupTestDir(t *testing.T, entries []*chlog.Entry) config.Config {
-	ctx := config.New(t.TempDir())
+	cfg := config.New(t.TempDir())
 
 	// Create a known dummy changelog which may be updated by the test
 	changelogBytes, err := os.ReadFile(filepath.Join("testdata", config.DefaultChangelogMD))
 	require.NoError(t, err)
-	require.NoError(t, os.WriteFile(ctx.ChangelogMD, changelogBytes, os.FileMode(0755)))
+	require.NoError(t, os.WriteFile(cfg.ChangelogMD, changelogBytes, os.FileMode(0755)))
 
-	require.NoError(t, os.Mkdir(ctx.ChloggenDir, os.FileMode(0755)))
+	require.NoError(t, os.Mkdir(cfg.ChlogsDir, os.FileMode(0755)))
 
 	// Copy the entry template, for tests that ensure it is not deleted
 	templateInRootDir := config.New("testdata").TemplateYAML
 	templateBytes, err := os.ReadFile(filepath.Clean(templateInRootDir))
 	require.NoError(t, err)
-	require.NoError(t, os.WriteFile(ctx.TemplateYAML, templateBytes, os.FileMode(0755)))
+	require.NoError(t, os.WriteFile(cfg.TemplateYAML, templateBytes, os.FileMode(0755)))
 
 	for i, entry := range entries {
-		require.NoError(t, writeEntryYAML(ctx, fmt.Sprintf("%d.yaml", i), entry))
+		require.NoError(t, writeEntryYAML(cfg, fmt.Sprintf("%d.yaml", i), entry))
 	}
 
-	return ctx
+	return cfg
 }
 
-func writeEntryYAML(ctx config.Config, filename string, entry *chlog.Entry) error {
+func writeEntryYAML(cfg config.Config, filename string, entry *chlog.Entry) error {
 	entryBytes, err := yaml.Marshal(entry)
 	if err != nil {
 		return err
 	}
-	path := filepath.Join(ctx.ChloggenDir, filename)
+	path := filepath.Join(cfg.ChlogsDir, filename)
 	return os.WriteFile(path, entryBytes, os.FileMode(0755))
 }
 

--- a/chloggen/cmd/new.go
+++ b/chloggen/cmd/new.go
@@ -31,7 +31,7 @@ func newCmd() *cobra.Command {
 		Use:   "new",
 		Short: "Creates new change file",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			path := filepath.Join(globalCfg.ChloggenDir, cleanFileName(filename))
+			path := filepath.Join(globalCfg.ChlogsDir, cleanFileName(filename))
 			var pathWithExt string
 			switch ext := filepath.Ext(path); ext {
 			case ".yaml":

--- a/chloggen/cmd/new_test.go
+++ b/chloggen/cmd/new_test.go
@@ -32,7 +32,7 @@ Flags:
   -h, --help              help for new
 
 Global Flags:
-      --chloggen-directory string   directory containing unreleased change log entries (default: .chloggen)`
+      --config string   (optional) chloggen config file`
 
 func TestNewErr(t *testing.T) {
 	var out, err string
@@ -56,27 +56,27 @@ func TestNew(t *testing.T) {
 	var out, err string
 
 	out, err = runCobra(t, "new", "--filename", "my-change")
-	assert.Contains(t, out, fmt.Sprintf("Changelog entry template copied to: %s", filepath.Join(globalCfg.ChloggenDir, "my-change.yaml")))
+	assert.Contains(t, out, fmt.Sprintf("Changelog entry template copied to: %s", filepath.Join(globalCfg.ChlogsDir, "my-change.yaml")))
 	assert.Empty(t, err)
 
 	out, err = runCobra(t, "new", "--filename", "some-change.yaml")
-	assert.Contains(t, out, fmt.Sprintf("Changelog entry template copied to: %s", filepath.Join(globalCfg.ChloggenDir, "some-change.yaml")))
+	assert.Contains(t, out, fmt.Sprintf("Changelog entry template copied to: %s", filepath.Join(globalCfg.ChlogsDir, "some-change.yaml")))
 	assert.Empty(t, err)
 
 	out, err = runCobra(t, "new", "--filename", "some-change.yml")
-	assert.Contains(t, out, fmt.Sprintf("Changelog entry template copied to: %s", filepath.Join(globalCfg.ChloggenDir, "some-change.yaml")))
+	assert.Contains(t, out, fmt.Sprintf("Changelog entry template copied to: %s", filepath.Join(globalCfg.ChlogsDir, "some-change.yaml")))
 	assert.Empty(t, err)
 
 	out, err = runCobra(t, "new", "--filename", "replace/forward/slash")
-	assert.Contains(t, out, fmt.Sprintf("Changelog entry template copied to: %s", filepath.Join(globalCfg.ChloggenDir, "replace_forward_slash.yaml")))
+	assert.Contains(t, out, fmt.Sprintf("Changelog entry template copied to: %s", filepath.Join(globalCfg.ChlogsDir, "replace_forward_slash.yaml")))
 	assert.Empty(t, err)
 
 	out, err = runCobra(t, "new", "--filename", "not.an.extension")
-	assert.Contains(t, out, fmt.Sprintf("Changelog entry template copied to: %s", filepath.Join(globalCfg.ChloggenDir, "not.an.extension.yaml")))
+	assert.Contains(t, out, fmt.Sprintf("Changelog entry template copied to: %s", filepath.Join(globalCfg.ChlogsDir, "not.an.extension.yaml")))
 	assert.Empty(t, err)
 
 	out, err = runCobra(t, "new", "--filename", "my-change.txt")
-	assert.Contains(t, out, fmt.Sprintf("Changelog entry template copied to: %s", filepath.Join(globalCfg.ChloggenDir, "my-change.txt.yaml")))
+	assert.Contains(t, out, fmt.Sprintf("Changelog entry template copied to: %s", filepath.Join(globalCfg.ChlogsDir, "my-change.txt.yaml")))
 	assert.Empty(t, err)
 }
 

--- a/chloggen/cmd/root.go
+++ b/chloggen/cmd/root.go
@@ -24,8 +24,8 @@ import (
 )
 
 var (
-	chloggenDir string
-	globalCfg   config.Config
+	configFile string
+	globalCfg  config.Config
 )
 
 func rootCmd() *cobra.Command {
@@ -34,7 +34,7 @@ func rootCmd() *cobra.Command {
 		Short: "Updates CHANGELOG.MD to include all new changes",
 		Long:  `chloggen is a tool used to automate the generation of CHANGELOG files using individual yaml files as the source.`,
 	}
-	cmd.PersistentFlags().StringVar(&chloggenDir, "chloggen-directory", "", "directory containing unreleased change log entries (default: .chloggen)")
+	cmd.PersistentFlags().StringVar(&configFile, "config", "", "(optional) chloggen config file")
 	cmd.AddCommand(newCmd())
 	cmd.AddCommand(updateCmd())
 	cmd.AddCommand(validateCmd())
@@ -56,10 +56,16 @@ func initConfig() {
 		return
 	}
 
-	if chloggenDir == "" {
-		chloggenDir = ".chloggen"
+	if configFile == "" {
+		globalCfg = config.New(repoRoot())
+	} else {
+		var err error
+		globalCfg, err = config.NewFromFile(repoRoot(), configFile)
+		if err != nil {
+			fmt.Printf("FAIL: Could not load config file: %s\n", err.Error())
+			os.Exit(1)
+		}
 	}
-	globalCfg = config.New(repoRoot(), config.WithChloggenDir(chloggenDir))
 }
 
 func repoRoot() string {

--- a/chloggen/cmd/root_test.go
+++ b/chloggen/cmd/root_test.go
@@ -33,8 +33,8 @@ Available Commands:
   validate    Validates the files in the changelog directory
 
 Flags:
-      --chloggen-directory string   directory containing unreleased change log entries (default: .chloggen)
-  -h, --help                        help for chloggen
+      --config string   (optional) chloggen config file
+  -h, --help            help for chloggen
 
 Use "chloggen [command] --help" for more information about a command.`
 
@@ -46,6 +46,10 @@ func TestRoot(t *testing.T) {
 	assert.Empty(t, err)
 
 	out, err = runCobra(t, "--help")
+	assert.Contains(t, out, rootUsage)
+	assert.Empty(t, err)
+
+	out, err = runCobra(t, "--config", "foo.yaml")
 	assert.Contains(t, out, rootUsage)
 	assert.Empty(t, err)
 }

--- a/chloggen/cmd/validate.go
+++ b/chloggen/cmd/validate.go
@@ -27,7 +27,7 @@ func validateCmd() *cobra.Command {
 		Use:   "validate",
 		Short: "Validates the files in the changelog directory",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if _, err := os.Stat(globalCfg.ChloggenDir); err != nil {
+			if _, err := os.Stat(globalCfg.ChlogsDir); err != nil {
 				return err
 			}
 
@@ -40,7 +40,7 @@ func validateCmd() *cobra.Command {
 					return err
 				}
 			}
-			cmd.Printf("PASS: all files in %s/ are valid\n", globalCfg.ChloggenDir)
+			cmd.Printf("PASS: all files in %s/ are valid\n", globalCfg.ChlogsDir)
 			return nil
 		},
 	}

--- a/chloggen/cmd/validate_test.go
+++ b/chloggen/cmd/validate_test.go
@@ -30,7 +30,7 @@ Flags:
   -h, --help   help for validate
 
 Global Flags:
-      --chloggen-directory string   directory containing unreleased change log entries (default: .chloggen)`
+      --config string   (optional) chloggen config file`
 
 func TestValidateErr(t *testing.T) {
 	var out, err string
@@ -148,7 +148,7 @@ func TestValidate(t *testing.T) {
 				assert.Regexp(t, tc.wantErr, err)
 			} else {
 				assert.Empty(t, err)
-				assert.Contains(t, out, fmt.Sprintf("PASS: all files in %s/ are valid", globalCfg.ChloggenDir))
+				assert.Contains(t, out, fmt.Sprintf("PASS: all files in %s/ are valid", globalCfg.ChlogsDir))
 			}
 		})
 	}

--- a/chloggen/internal/chlog/entry.go
+++ b/chloggen/internal/chlog/entry.go
@@ -94,14 +94,14 @@ func (e Entry) String() string {
 }
 
 func ReadEntries(cfg config.Config) ([]*Entry, error) {
-	entryYAMLs, err := filepath.Glob(filepath.Join(cfg.ChloggenDir, "*.yaml"))
+	entryYAMLs, err := filepath.Glob(filepath.Join(cfg.ChlogsDir, "*.yaml"))
 	if err != nil {
 		return nil, err
 	}
 
 	entries := make([]*Entry, 0, len(entryYAMLs))
 	for _, entryYAML := range entryYAMLs {
-		if filepath.Base(entryYAML) == filepath.Base(cfg.TemplateYAML) {
+		if entryYAML == cfg.TemplateYAML || entryYAML == cfg.ConfigYAML {
 			continue
 		}
 
@@ -120,7 +120,7 @@ func ReadEntries(cfg config.Config) ([]*Entry, error) {
 }
 
 func DeleteEntries(cfg config.Config) error {
-	entryYAMLs, err := filepath.Glob(filepath.Join(cfg.ChloggenDir, "*.yaml"))
+	entryYAMLs, err := filepath.Glob(filepath.Join(cfg.ChlogsDir, "*.yaml"))
 	if err != nil {
 		return err
 	}

--- a/chloggen/internal/chlog/entry_test.go
+++ b/chloggen/internal/chlog/entry_test.go
@@ -157,7 +157,19 @@ func TestReadDeleteEntries(t *testing.T) {
 	_, err = fileB.Write(bytesB)
 	require.NoError(t, err)
 
+	// Put config and template files in chlogs_dir to ensure they are ignored when reading/deleting entries
+	configYAML, err := os.CreateTemp(entriesDir, "config.yaml")
+	require.NoError(t, err)
+	defer configYAML.Close()
+
+	templateYAML, err := os.CreateTemp(entriesDir, "TEMPLATE.yaml")
+	require.NoError(t, err)
+	defer templateYAML.Close()
+
 	cfg := config.New(tempDir)
+	cfg.ConfigYAML = configYAML.Name()
+	cfg.TemplateYAML = templateYAML.Name()
+
 	entries, err := ReadEntries(cfg)
 	assert.NoError(t, err)
 
@@ -167,4 +179,8 @@ func TestReadDeleteEntries(t *testing.T) {
 	entries, err = ReadEntries(cfg)
 	assert.NoError(t, err)
 	assert.Empty(t, entries)
+
+	// Ensure these weren't deleted
+	assert.FileExists(t, cfg.ConfigYAML)
+	assert.FileExists(t, cfg.TemplateYAML)
 }

--- a/chloggen/internal/config/config.tmpl
+++ b/chloggen/internal/config/config.tmpl
@@ -1,0 +1,17 @@
+# The directory that stores individual chlog files. Each chlog file represents
+# a single changelog entry.
+# - 'chloggen new' will copy the 'template_yaml' to this directory as a new chlog file.
+# - 'chloggen validate' will validate that all chlog files are valid.
+# - 'chloggen update' will read and delete all chlog files in this directory, and update 'changelog_md'.
+# Specify as relative path from root of repo.
+# (Optional) Default: .chloggen
+# chlogs_dir:
+
+# The CHANGELOG file to which 'chloggen update' will write new entries
+# (Optional) Default: CHANGELOG.md
+# changelog_md:
+
+# This file is used as the input for individul changelog entries.
+# Specify as relative path from root of repo.
+# (Optional) Default: .chloggen/TEMPLATE.yaml
+# template_yaml:

--- a/chloggen/internal/config/config_test.go
+++ b/chloggen/internal/config/config_test.go
@@ -15,27 +15,62 @@
 package config
 
 import (
+	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
 )
 
 func TestNew(t *testing.T) {
 	root := "/tmp"
-	ctx := New(root)
-	assert.Equal(t, root, ctx.rootDir)
-	assert.Equal(t, filepath.Join(root, DefaultChloggenDir), ctx.ChloggenDir)
-	assert.Equal(t, filepath.Join(root, DefaultChangelogMD), ctx.ChangelogMD)
-	assert.Equal(t, filepath.Join(root, DefaultChloggenDir, DefaultTemplateYAML), ctx.TemplateYAML)
+	cfg := New(root)
+	assert.Equal(t, filepath.Join(root, DefaultChloggenDir), cfg.ChlogsDir)
+	assert.Equal(t, filepath.Join(root, DefaultChangelogMD), cfg.ChangelogMD)
+	assert.Equal(t, filepath.Join(root, DefaultChloggenDir, DefaultTemplateYAML), cfg.TemplateYAML)
 }
 
-func TestWithChloggenDir(t *testing.T) {
-	root := "/tmp"
-	chloggenDir := ".test"
-	ctx := New(root, WithChloggenDir(chloggenDir))
-	assert.Equal(t, root, ctx.rootDir)
-	assert.Equal(t, filepath.Join(root, chloggenDir), ctx.ChloggenDir)
-	assert.Equal(t, filepath.Join(root, DefaultChangelogMD), ctx.ChangelogMD)
-	assert.Equal(t, filepath.Join(root, chloggenDir, DefaultTemplateYAML), ctx.TemplateYAML)
+func TestNewFromFile(t *testing.T) {
+	tempDir := t.TempDir()
+
+	cfg := New(tempDir)
+	cfg.ChlogsDir = ".test"
+	cfg.ChangelogMD = "CHANGELOG-custom.md"
+	cfg.TemplateYAML = "TEMPLATE-custom.yaml"
+
+	cfgBytes, err := yaml.Marshal(cfg)
+	require.NoError(t, err)
+
+	cfgFile, err := os.CreateTemp(tempDir, "*.yaml")
+	require.NoError(t, err)
+	defer cfgFile.Close()
+
+	_, err = cfgFile.Write(cfgBytes)
+	require.NoError(t, err)
+
+	actualCfg, err := NewFromFile(tempDir, filepath.Base(cfgFile.Name()))
+	assert.NoError(t, err)
+	assert.Equal(t, filepath.Join(tempDir, ".test"), actualCfg.ChlogsDir)
+	assert.Equal(t, filepath.Join(tempDir, "CHANGELOG-custom.md"), actualCfg.ChangelogMD)
+	assert.Equal(t, filepath.Join(tempDir, "TEMPLATE-custom.yaml"), actualCfg.TemplateYAML)
+}
+
+func TestNewFromFileErr(t *testing.T) {
+	tempDir := t.TempDir()
+
+	_, err := NewFromFile(tempDir, "nonexistent.yaml")
+	assert.Error(t, err)
+
+	// Write a file with invalid YAML and then read it back to get expected error
+	cfgFile, err := os.CreateTemp(tempDir, "*.yaml")
+	require.NoError(t, err)
+	defer cfgFile.Close()
+
+	_, err = cfgFile.WriteString("!@#$%^&*())")
+	require.NoError(t, err)
+
+	_, err = NewFromFile(tempDir, filepath.Base(cfgFile.Name()))
+	assert.Error(t, err)
 }


### PR DESCRIPTION
This PR introduces an optional repo-level configuration file for the chloggen tool. 
- Add a global `--config` flag that can be used to specify a config file.
- Removes the `chloggen-directory` flag, which is not used anywhere in our org. Instead, this value can be specified within the config file.
- Renames the `ChloggenDir` field to `ChlogsDir`, since it is no longer required that this directory be used for "meta" files, such as config and template.
- Ensures that "meta" files (config, template) are ignored when reading/deleting entries. This allows for these files to be placed in the chlogs dir, or not.
- Adds an example config file that can be copied into place when setting up a repo. In the future this can likely be handled by a `chloggen init` command.