### PR TITLE
semconvgen: Quickfix after semconv repo migration

### DIFF
--- a/.chloggen/semconvgen-quickfix.yaml
+++ b/.chloggen/semconvgen-quickfix.yaml
@@ -1,11 +1,11 @@
 # One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
-change_type: enhancement
+change_type: bug_fix
 
 # The name of the component, or a single word describing the area of concern, (e.g. crosslink)
 component: semconvgen
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: Make semconvgen working for the new semantic conventions repository.
+note: Fix semconvgen to work for the new semantic conventions repository.
 
 # One or more tracking issues related to the change
 issues: [374]

--- a/.chloggen/semconvgen-quickfix.yaml
+++ b/.chloggen/semconvgen-quickfix.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. crosslink)
+component: semconvgen
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Make semconvgen working for the new semantic conventions repository.
+
+# One or more tracking issues related to the change
+issues: [374]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/semconvgen/generator.go
+++ b/semconvgen/generator.go
@@ -166,7 +166,7 @@ func render(cfg config) error {
 		"run", "--rm",
 		"-v", fmt.Sprintf("%s:/data:Z", tmpDir),
 		cfg.containerImage,
-		"--yaml-root", path.Join("/data/input/semantic_conventions/", path.Base(cfg.inputPath)),
+		"--yaml-root", path.Join("/data/input/model/", path.Base(cfg.inputPath)),
 	}
 	if cfg.onlyType != "" {
 		args = append(args, "--only", cfg.onlyType)


### PR DESCRIPTION
This is "quickfix" for `semconvgen` so that the OTel Collector and Go can use `semconvgen` after the semantic conventions moved from https://github.com/open-telemetry/opentelemetry-specification to https://github.com/open-telemetry/semantic-conventions.

This change was tested as part of https://github.com/open-telemetry/opentelemetry-go/pull/4362

A more sophisticated way would be probably to have two args in  `semconvgen`; one for the Git repository and second for folder when the YAML definitions reside. However, I think that it may be not worth the effort and could introduce more problems than benefits (both OTel Collector and Go would need to update their semconv generation scripts).