### PR TITLE
Chloggen clarify termininology

### DIFF
--- a/chloggen/cmd/cmd_test.go
+++ b/chloggen/cmd/cmd_test.go
@@ -123,8 +123,8 @@ func setupTestDir(t *testing.T, entries []*chlog.Entry) {
 		require.NoError(t, os.WriteFile(filename, changelogBytes, os.FileMode(0755)))
 	}
 
-	// Create the chlogs directory
-	require.NoError(t, os.MkdirAll(globalCfg.ChlogsDir, os.FileMode(0755)))
+	// Create the entries directory
+	require.NoError(t, os.MkdirAll(globalCfg.EntriesDir, os.FileMode(0755)))
 
 	// Copy the entry template, for tests that ensure it is not deleted
 	templateInRootDir := config.New("testdata").TemplateYAML
@@ -132,11 +132,11 @@ func setupTestDir(t *testing.T, entries []*chlog.Entry) {
 	require.NoError(t, err)
 	require.NoError(t, os.WriteFile(globalCfg.TemplateYAML, templateBytes, os.FileMode(0755)))
 
-	// Write the entries to the chlogs directory
+	// Write the entries to the entries directory
 	for i, entry := range entries {
 		entryBytes, err := yaml.Marshal(entry)
 		require.NoError(t, err)
-		path := filepath.Join(globalCfg.ChlogsDir, fmt.Sprintf("%d.yaml", i))
+		path := filepath.Join(globalCfg.EntriesDir, fmt.Sprintf("%d.yaml", i))
 		require.NoError(t, os.WriteFile(path, entryBytes, os.FileMode(0755)))
 	}
 }

--- a/chloggen/cmd/new.go
+++ b/chloggen/cmd/new.go
@@ -31,7 +31,7 @@ func newCmd() *cobra.Command {
 		Use:   "new",
 		Short: "Creates new change file",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			path := filepath.Join(globalCfg.ChlogsDir, cleanFileName(filename))
+			path := filepath.Join(globalCfg.EntriesDir, cleanFileName(filename))
 			var pathWithExt string
 			switch ext := filepath.Ext(path); ext {
 			case ".yaml":

--- a/chloggen/cmd/new_test.go
+++ b/chloggen/cmd/new_test.go
@@ -58,27 +58,27 @@ func TestNew(t *testing.T) {
 	var out, err string
 
 	out, err = runCobra(t, "new", "--filename", "my-change")
-	assert.Contains(t, out, fmt.Sprintf("Changelog entry template copied to: %s", filepath.Join(globalCfg.ChlogsDir, "my-change.yaml")))
+	assert.Contains(t, out, fmt.Sprintf("Changelog entry template copied to: %s", filepath.Join(globalCfg.EntriesDir, "my-change.yaml")))
 	assert.Empty(t, err)
 
 	out, err = runCobra(t, "new", "--filename", "some-change.yaml")
-	assert.Contains(t, out, fmt.Sprintf("Changelog entry template copied to: %s", filepath.Join(globalCfg.ChlogsDir, "some-change.yaml")))
+	assert.Contains(t, out, fmt.Sprintf("Changelog entry template copied to: %s", filepath.Join(globalCfg.EntriesDir, "some-change.yaml")))
 	assert.Empty(t, err)
 
 	out, err = runCobra(t, "new", "--filename", "some-change.yml")
-	assert.Contains(t, out, fmt.Sprintf("Changelog entry template copied to: %s", filepath.Join(globalCfg.ChlogsDir, "some-change.yaml")))
+	assert.Contains(t, out, fmt.Sprintf("Changelog entry template copied to: %s", filepath.Join(globalCfg.EntriesDir, "some-change.yaml")))
 	assert.Empty(t, err)
 
 	out, err = runCobra(t, "new", "--filename", "replace/forward/slash")
-	assert.Contains(t, out, fmt.Sprintf("Changelog entry template copied to: %s", filepath.Join(globalCfg.ChlogsDir, "replace_forward_slash.yaml")))
+	assert.Contains(t, out, fmt.Sprintf("Changelog entry template copied to: %s", filepath.Join(globalCfg.EntriesDir, "replace_forward_slash.yaml")))
 	assert.Empty(t, err)
 
 	out, err = runCobra(t, "new", "--filename", "not.an.extension")
-	assert.Contains(t, out, fmt.Sprintf("Changelog entry template copied to: %s", filepath.Join(globalCfg.ChlogsDir, "not.an.extension.yaml")))
+	assert.Contains(t, out, fmt.Sprintf("Changelog entry template copied to: %s", filepath.Join(globalCfg.EntriesDir, "not.an.extension.yaml")))
 	assert.Empty(t, err)
 
 	out, err = runCobra(t, "new", "--filename", "my-change.txt")
-	assert.Contains(t, out, fmt.Sprintf("Changelog entry template copied to: %s", filepath.Join(globalCfg.ChlogsDir, "my-change.txt.yaml")))
+	assert.Contains(t, out, fmt.Sprintf("Changelog entry template copied to: %s", filepath.Join(globalCfg.EntriesDir, "my-change.txt.yaml")))
 	assert.Empty(t, err)
 }
 

--- a/chloggen/cmd/update_test.go
+++ b/chloggen/cmd/update_test.go
@@ -49,7 +49,7 @@ func TestUpdateErr(t *testing.T) {
 	assert.Contains(t, out, updateUsage)
 	assert.Empty(t, err)
 
-	badEntry, ioErr := os.CreateTemp(globalCfg.ChlogsDir, "*.yaml")
+	badEntry, ioErr := os.CreateTemp(globalCfg.EntriesDir, "*.yaml")
 	require.NoError(t, ioErr)
 	defer badEntry.Close()
 
@@ -232,7 +232,7 @@ func TestUpdate(t *testing.T) {
 
 				require.Equal(t, string(expectedBytes), string(actualBytes))
 
-				remainingYAMLs, ioErr := filepath.Glob(filepath.Join(globalCfg.ChlogsDir, "*.yaml"))
+				remainingYAMLs, ioErr := filepath.Glob(filepath.Join(globalCfg.EntriesDir, "*.yaml"))
 				require.NoError(t, ioErr)
 				if tc.dry {
 					require.Equal(t, 1+len(tc.entries), len(remainingYAMLs))

--- a/chloggen/cmd/validate.go
+++ b/chloggen/cmd/validate.go
@@ -27,7 +27,7 @@ func validateCmd() *cobra.Command {
 		Use:   "validate",
 		Short: "Validates the files in the changelog directory",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if _, err := os.Stat(globalCfg.ChlogsDir); err != nil {
+			if _, err := os.Stat(globalCfg.EntriesDir); err != nil {
 				return err
 			}
 
@@ -47,7 +47,7 @@ func validateCmd() *cobra.Command {
 					}
 				}
 			}
-			cmd.Printf("PASS: all files in %s/ are valid\n", globalCfg.ChlogsDir)
+			cmd.Printf("PASS: all files in %s/ are valid\n", globalCfg.EntriesDir)
 			return nil
 		},
 	}

--- a/chloggen/cmd/validate_test.go
+++ b/chloggen/cmd/validate_test.go
@@ -150,7 +150,7 @@ func TestValidate(t *testing.T) {
 				assert.Regexp(t, tc.wantErr, err)
 			} else {
 				assert.Empty(t, err)
-				assert.Contains(t, out, fmt.Sprintf("PASS: all files in %s/ are valid", globalCfg.ChlogsDir))
+				assert.Contains(t, out, fmt.Sprintf("PASS: all files in %s/ are valid", globalCfg.EntriesDir))
 			}
 		})
 	}

--- a/chloggen/internal/chlog/entry.go
+++ b/chloggen/internal/chlog/entry.go
@@ -62,7 +62,7 @@ func (e Entry) Validate(requireChangelog bool, validChangeLogs ...string) error 
 			}
 		}
 		if !valid {
-			return fmt.Errorf("'%s' is not a valid 'change_log'. Specify one of %v", cl, validChangeLogs)
+			return fmt.Errorf("'%s' is not a valid value in 'change_logs'. Specify one of %v", cl, validChangeLogs)
 		}
 	}
 
@@ -110,7 +110,7 @@ func (e Entry) String() string {
 }
 
 func ReadEntries(cfg *config.Config) (map[string][]*Entry, error) {
-	yamlFiles, err := filepath.Glob(filepath.Join(cfg.ChlogsDir, "*.yaml"))
+	yamlFiles, err := filepath.Glob(filepath.Join(cfg.EntriesDir, "*.yaml"))
 	if err != nil {
 		return nil, err
 	}
@@ -149,7 +149,7 @@ func ReadEntries(cfg *config.Config) (map[string][]*Entry, error) {
 }
 
 func DeleteEntries(cfg *config.Config) error {
-	yamlFiles, err := filepath.Glob(filepath.Join(cfg.ChlogsDir, "*.yaml"))
+	yamlFiles, err := filepath.Glob(filepath.Join(cfg.EntriesDir, "*.yaml"))
 	if err != nil {
 		return err
 	}

--- a/chloggen/internal/chlog/entry_test.go
+++ b/chloggen/internal/chlog/entry_test.go
@@ -94,7 +94,7 @@ func TestEntry(t *testing.T) {
 				SubText:    "",
 			},
 			validChangeLogs: []string{"foo"},
-			expectErr:       "'bar' is not a valid 'change_log'. Specify one of [foo]",
+			expectErr:       "'bar' is not a valid value in 'change_logs'. Specify one of [foo]",
 		},
 		{
 			name: "valid",
@@ -215,7 +215,7 @@ func TestEntry(t *testing.T) {
 
 func TestReadDeleteEntries(t *testing.T) {
 	tempDir := t.TempDir()
-	entriesDir := filepath.Join(tempDir, config.DefaultChlogsDir)
+	entriesDir := filepath.Join(tempDir, config.DefaultEntriesDir)
 	require.NoError(t, os.Mkdir(entriesDir, os.ModePerm))
 
 	entryA := Entry{
@@ -255,7 +255,7 @@ func TestReadDeleteEntries(t *testing.T) {
 	}
 	writeEntry(t, entriesDir, &entryD)
 
-	// Put config and template files in chlogs_dir to ensure they are ignored when reading/deleting entries
+	// Put config and template files in entries_dir to ensure they are ignored when reading/deleting entries
 	configYAML, err := os.Create(filepath.Join(entriesDir, "config.yaml")) //nolint:gosec
 	require.NoError(t, err)
 	defer configYAML.Close()
@@ -272,7 +272,7 @@ func TestReadDeleteEntries(t *testing.T) {
 			"bar": filepath.Join(entriesDir, "CHANGELOG.bar.md"),
 		},
 		DefaultChangeLogs: []string{"foo"},
-		ChlogsDir:         entriesDir,
+		EntriesDir:        entriesDir,
 	}
 
 	changeLogEntries, err := ReadEntries(cfg)

--- a/chloggen/internal/config/config.go
+++ b/chloggen/internal/config/config.go
@@ -25,7 +25,7 @@ import (
 )
 
 const (
-	DefaultChlogsDir         = ".chloggen"
+	DefaultEntriesDir        = ".chloggen"
 	DefaultTemplateYAML      = "TEMPLATE.yaml"
 	DefaultChangeLogKey      = "default"
 	DefaultChangeLogFilename = "CHANGELOG.md"
@@ -34,7 +34,7 @@ const (
 type Config struct {
 	ChangeLogs        map[string]string `yaml:"change_logs"`
 	DefaultChangeLogs []string          `yaml:"default_change_logs"`
-	ChlogsDir         string            `yaml:"chlogs_dir"`
+	EntriesDir        string            `yaml:"entries_dir"`
 	TemplateYAML      string            `yaml:"template_yaml"`
 	ConfigYAML        string
 }
@@ -43,8 +43,8 @@ func New(rootDir string) *Config {
 	return &Config{
 		ChangeLogs:        map[string]string{DefaultChangeLogKey: filepath.Join(rootDir, DefaultChangeLogFilename)},
 		DefaultChangeLogs: []string{DefaultChangeLogKey},
-		ChlogsDir:         filepath.Join(rootDir, DefaultChlogsDir),
-		TemplateYAML:      filepath.Join(rootDir, DefaultChlogsDir, DefaultTemplateYAML),
+		EntriesDir:        filepath.Join(rootDir, DefaultEntriesDir),
+		TemplateYAML:      filepath.Join(rootDir, DefaultEntriesDir, DefaultTemplateYAML),
 	}
 }
 
@@ -60,14 +60,14 @@ func NewFromFile(rootDir string, cfgFilename string) (*Config, error) {
 	}
 
 	cfg.ConfigYAML = cfgYAML
-	if cfg.ChlogsDir == "" {
-		cfg.ChlogsDir = filepath.Join(rootDir, DefaultChlogsDir)
-	} else if !strings.HasPrefix(cfg.ChlogsDir, rootDir) {
-		cfg.ChlogsDir = filepath.Join(rootDir, cfg.ChlogsDir)
+	if cfg.EntriesDir == "" {
+		cfg.EntriesDir = filepath.Join(rootDir, DefaultEntriesDir)
+	} else if !strings.HasPrefix(cfg.EntriesDir, rootDir) {
+		cfg.EntriesDir = filepath.Join(rootDir, cfg.EntriesDir)
 	}
 
 	if cfg.TemplateYAML == "" {
-		cfg.TemplateYAML = filepath.Join(rootDir, DefaultChlogsDir, DefaultTemplateYAML)
+		cfg.TemplateYAML = filepath.Join(rootDir, DefaultEntriesDir, DefaultTemplateYAML)
 	} else if !strings.HasPrefix(cfg.TemplateYAML, rootDir) {
 		cfg.TemplateYAML = filepath.Join(rootDir, cfg.TemplateYAML)
 	}

--- a/chloggen/internal/config/config.yaml
+++ b/chloggen/internal/config/config.yaml
@@ -1,11 +1,11 @@
-# The directory that stores individual chlog files. Each chlog file represents
-# a single changelog entry.
-# - 'chloggen new' will copy the 'template_yaml' to this directory as a new chlog file.
-# - 'chloggen validate' will validate that all chlog files are valid.
-# - 'chloggen update' will read and delete all chlog files in this directory, and update 'changelog_md'.
+# The directory that stores individual changelog entries.
+# Each entry is stored in a dedicated yaml file.
+# - 'chloggen new' will copy the 'template_yaml' to this directory as a new entry file.
+# - 'chloggen validate' will validate that all entry files are valid.
+# - 'chloggen update' will read and delete all entry files in this directory, and update 'changelog_md'.
 # Specify as relative path from root of repo.
 # (Optional) Default: .chloggen
-# chlogs_dir:
+# entries_dir:
 
 # This file is used as the input for individul changelog entries.
 # Specify as relative path from root of repo.

--- a/chloggen/internal/config/config_test.go
+++ b/chloggen/internal/config/config_test.go
@@ -27,8 +27,8 @@ import (
 func TestNew(t *testing.T) {
 	root := "/tmp"
 	cfg := New(root)
-	assert.Equal(t, filepath.Join(root, DefaultChlogsDir), cfg.ChlogsDir)
-	assert.Equal(t, filepath.Join(root, DefaultChlogsDir, DefaultTemplateYAML), cfg.TemplateYAML)
+	assert.Equal(t, filepath.Join(root, DefaultEntriesDir), cfg.EntriesDir)
+	assert.Equal(t, filepath.Join(root, DefaultEntriesDir, DefaultTemplateYAML), cfg.TemplateYAML)
 
 	assert.Equal(t, 1, len(cfg.ChangeLogs))
 	assert.NotNil(t, cfg.ChangeLogs[DefaultChangeLogKey])
@@ -51,7 +51,7 @@ func TestNewFromFile(t *testing.T) {
 		{
 			name: "multi-changelog-no-default",
 			cfg: &Config{
-				ChlogsDir:    ".test",
+				EntriesDir:   ".test",
 				TemplateYAML: "TEMPLATE-custom.yaml",
 				ChangeLogs: map[string]string{
 					"foo": "CHANGELOG-1.md",
@@ -62,7 +62,7 @@ func TestNewFromFile(t *testing.T) {
 		{
 			name: "multi-changelog-with-default",
 			cfg: &Config{
-				ChlogsDir:    ".test",
+				EntriesDir:   ".test",
 				TemplateYAML: "TEMPLATE-custom.yaml",
 				ChangeLogs: map[string]string{
 					"foo": "CHANGELOG-1.md",
@@ -74,7 +74,7 @@ func TestNewFromFile(t *testing.T) {
 		{
 			name: "default-changelogs-without-changelogs",
 			cfg: &Config{
-				ChlogsDir:         ".test",
+				EntriesDir:        ".test",
 				TemplateYAML:      "TEMPLATE-custom.yaml",
 				DefaultChangeLogs: []string{"foo"},
 			},
@@ -83,7 +83,7 @@ func TestNewFromFile(t *testing.T) {
 		{
 			name: "default-changelog-not-in-changelogs",
 			cfg: &Config{
-				ChlogsDir:    ".test",
+				EntriesDir:   ".test",
 				TemplateYAML: "TEMPLATE-custom.yaml",
 				ChangeLogs: map[string]string{
 					"foo": "CHANGELOG-1.md",
@@ -120,11 +120,11 @@ func TestNewFromFile(t *testing.T) {
 			// Instantiate it here to compare against the actual config as appropriate.
 			defaultCfg := New(tempDir)
 
-			expectedChlogsDir := defaultCfg.ChlogsDir
-			if tc.cfg.ChlogsDir != "" {
-				expectedChlogsDir = filepath.Join(tempDir, tc.cfg.ChlogsDir)
+			expectedEntriesDir := defaultCfg.EntriesDir
+			if tc.cfg.EntriesDir != "" {
+				expectedEntriesDir = filepath.Join(tempDir, tc.cfg.EntriesDir)
 			}
-			assert.Equal(t, expectedChlogsDir, actualCfg.ChlogsDir)
+			assert.Equal(t, expectedEntriesDir, actualCfg.EntriesDir)
 
 			expectedTeamplateYAML := defaultCfg.TemplateYAML
 			if tc.cfg.TemplateYAML != "" {


### PR DESCRIPTION
This is intended as a quick follow up to #372. Mostly it just standardizes on the terms "entry/entries" instead of "chlog/chlogs".