### PR TITLE
[chore] update go version used in workflows

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v4
         with:
-          go-version: "1.21"
+          go-version: "~1.21.1"
       - name: Cache Go
         id: go-cache
         uses: actions/cache@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ env:
   # Path to where test results will be saved.
   TEST_RESULTS: /tmp/test-results
   # Default minimum version of Go to support.
-  DEFAULT_GO_VERSION: "1.21"
+  DEFAULT_GO_VERSION: "~1.21.1"
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/create-dependabot-pr.yml
+++ b/.github/workflows/create-dependabot-pr.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v4
         with:
-          go-version: "1.21"
+          go-version: "~1.21.1"
 
       - name: Run dependabot-pr.sh
         run: ./.github/workflows/scripts/dependabot-pr.sh


### PR DESCRIPTION
This is a defensive PR to update the minimum go version used in GHA workflows. The latest patch version contains security related fixes. 