### PR TITLE
[multimod] change return code for diff

### DIFF
--- a/.chloggen/multimod-diff-rc.yaml
+++ b/.chloggen/multimod-diff-rc.yaml
@@ -1,0 +1,9 @@
+change_type: bugfix
+
+component: multimod
+
+note: Changes the return code for diff to match the behaviour it is replacing
+
+issues: []
+
+subtext:

--- a/.chloggen/multimod-diff-rc.yaml
+++ b/.chloggen/multimod-diff-rc.yaml
@@ -4,6 +4,6 @@ component: multimod
 
 note: Changes the return code for diff to match the behaviour it is replacing
 
-issues: []
+issues: [404]
 
 subtext:

--- a/.chloggen/multimod-diff-rc.yaml
+++ b/.chloggen/multimod-diff-rc.yaml
@@ -1,4 +1,4 @@
-change_type: bugfix
+change_type: bug_fix
 
 component: multimod
 

--- a/.chloggen/multimod-diff-rc.yaml
+++ b/.chloggen/multimod-diff-rc.yaml
@@ -2,8 +2,8 @@ change_type: bug_fix
 
 component: multimod
 
-note: Changes the return code for diff to match the behaviour it is replacing
+note: Return a non-0 exit code if there are no changes to ensure the build does not proceed with the release
 
 issues: [404]
 
-subtext:
+subtext:  This changes the exit code for `diff` to match the behaviour it is replacing in the Collector

--- a/multimod/cmd/diff.go
+++ b/multimod/cmd/diff.go
@@ -32,9 +32,10 @@ var diffCmd = &cobra.Command{
 		}
 
 		if len(changedFiles) > 0 {
-			log.Fatalf("The following files changed in %s modules since %s: \n%s\nRelease is required for %s modset", moduleSetName, previousVersion, strings.Join(changedFiles, "\n"), moduleSetName)
+			log.Printf("The following files changed in %s modules since %s: \n%s\nRelease is required for %s modset", moduleSetName, previousVersion, strings.Join(changedFiles, "\n"), moduleSetName)
+		} else {
+			log.Fatalf("No %s modules have changed since %s", moduleSetName, previousVersion)
 		}
-		log.Printf("No %s modules have changed since %s", moduleSetName, previousVersion)
 	},
 }
 


### PR DESCRIPTION
This matches the behaviour it was intended on replacing in the collector repository. It returns an error if there's no diff to ensure the build does not proceed with the release in that case.

This fixes https://github.com/open-telemetry/opentelemetry-collector/issues/8149