### PR TITLE
multimod: ignore `excluded-modules` when `-a` flag is enabled

### DIFF
--- a/.chloggen/codeboten_add-ignore-excluded.yaml
+++ b/.chloggen/codeboten_add-ignore-excluded.yaml
@@ -5,7 +5,7 @@ change_type: enhancement
 component: multimod
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: add ignore-excluded flag to support 
+note: ignore excluded-modules when -a flag is enabled
 
 # One or more tracking issues related to the change
 issues: [442]
@@ -14,7 +14,7 @@ issues: [442]
 # These lines will be padded with 2 spaces and then inserted directly into the document.
 # Use pipe (|) for multiline entries.
 subtext: |
-  This flag allows users of the sync command to sync all modules in a monorepo, including
+  This allows users of the sync command to sync all modules in a monorepo, including
   those listed in the excluded-modules. This is useful for repositories where some modules
   may not yet be ready for releasing (therefore listed under excluded-modules) but their
   dependencies still need to be managed via multimod.

--- a/.chloggen/codeboten_add-ignore-excluded.yaml
+++ b/.chloggen/codeboten_add-ignore-excluded.yaml
@@ -1,0 +1,20 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. crosslink)
+component: multimod
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: add ignore-excluded flag to support 
+
+# One or more tracking issues related to the change
+issues: [442]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  This flag allows users of the sync command to sync all modules in a monorepo, including
+  those listed in the excluded-modules. This is useful for repositories where some modules
+  may not yet be ready for releasing (therefore listed under excluded-modules) but their
+  dependencies still need to be managed via multimod.

--- a/multimod/cmd/sync.go
+++ b/multimod/cmd/sync.go
@@ -25,12 +25,13 @@ import (
 )
 
 var (
-	otherVersioningFile string
-	otherRepoRoot       string
-	otherVersionCommit  string
-	allModuleSetsSync   bool
-	moduleSetNamesSync  []string
-	skipGoModTidySync   bool
+	otherVersioningFile   string
+	otherRepoRoot         string
+	otherVersionCommit    string
+	allModuleSetsSync     bool
+	moduleSetNamesSync    []string
+	skipGoModTidySync     bool
+	ignoreExcludedModules bool
 )
 
 // syncCmd represents the sync command
@@ -62,7 +63,7 @@ var syncCmd = &cobra.Command{
 			otherVersioningFile = filepath.Join(otherRepoRoot,
 				fmt.Sprintf("%v.%v", defaultVersionsConfigName, defaultVersionsConfigType))
 		}
-		sync.Run(versioningFile, otherVersioningFile, otherRepoRoot, moduleSetNamesSync, otherVersionCommit, allModuleSetsSync, skipGoModTidySync)
+		sync.Run(versioningFile, otherVersioningFile, otherRepoRoot, moduleSetNamesSync, otherVersionCommit, allModuleSetsSync, skipGoModTidySync, ignoreExcludedModules)
 	},
 }
 
@@ -104,4 +105,8 @@ func init() {
 		"Specify this flag to skip invoking `go mod tidy`. "+
 			"To be used for debugging purposes. Should not be skipped during actual release.",
 	)
+
+	syncCmd.Flags().BoolVarP(&ignoreExcludedModules, "ignore-excluded", "", false,
+		"Specify this flag to ignore the excluded-modules section "+
+			"of the versioning file.")
 }

--- a/multimod/cmd/sync.go
+++ b/multimod/cmd/sync.go
@@ -25,13 +25,12 @@ import (
 )
 
 var (
-	otherVersioningFile   string
-	otherRepoRoot         string
-	otherVersionCommit    string
-	allModuleSetsSync     bool
-	moduleSetNamesSync    []string
-	skipGoModTidySync     bool
-	ignoreExcludedModules bool
+	otherVersioningFile string
+	otherRepoRoot       string
+	otherVersionCommit  string
+	allModuleSetsSync   bool
+	moduleSetNamesSync  []string
+	skipGoModTidySync   bool
 )
 
 // syncCmd represents the sync command
@@ -63,7 +62,7 @@ var syncCmd = &cobra.Command{
 			otherVersioningFile = filepath.Join(otherRepoRoot,
 				fmt.Sprintf("%v.%v", defaultVersionsConfigName, defaultVersionsConfigType))
 		}
-		sync.Run(versioningFile, otherVersioningFile, otherRepoRoot, moduleSetNamesSync, otherVersionCommit, allModuleSetsSync, skipGoModTidySync, ignoreExcludedModules)
+		sync.Run(versioningFile, otherVersioningFile, otherRepoRoot, moduleSetNamesSync, otherVersionCommit, allModuleSetsSync, skipGoModTidySync)
 	},
 }
 
@@ -105,8 +104,4 @@ func init() {
 		"Specify this flag to skip invoking `go mod tidy`. "+
 			"To be used for debugging purposes. Should not be skipped during actual release.",
 	)
-
-	syncCmd.Flags().BoolVarP(&ignoreExcludedModules, "ignore-excluded", "", false,
-		"Specify this flag to ignore the excluded-modules section "+
-			"of the versioning file.")
 }

--- a/multimod/internal/common/module_versioning.go
+++ b/multimod/internal/common/module_versioning.go
@@ -26,14 +26,17 @@ type ModuleVersioning struct {
 	ModInfoMap ModuleInfoMap
 }
 
-// NewModuleVersioning returns a ModuleVersioning struct from a versioning file and repo root.
-func NewModuleVersioning(versioningFilename string, repoRoot string) (ModuleVersioning, error) {
+// NewModuleVersioningWithIgnoreExcluded returns a ModuleVersioning struct from a versioning file and repo root and supports
+// ignoring the excluded-modules configuration.
+func NewModuleVersioningWithIgnoreExcluded(versioningFilename string, repoRoot string, ignoreExcluded bool) (ModuleVersioning, error) {
 	repoRoot, err := filepath.Abs(repoRoot)
 	if err != nil {
 		return ModuleVersioning{}, fmt.Errorf("could not get absolute path of repo root: %w", err)
 	}
 
 	vCfg, err := readVersioningFile(versioningFilename)
+	vCfg.ignoreExcluded = ignoreExcluded
+
 	if err != nil {
 		return ModuleVersioning{}, fmt.Errorf("error reading versioning file %v: %w", versioningFilename, err)
 	}
@@ -55,4 +58,9 @@ func NewModuleVersioning(versioningFilename string, repoRoot string) (ModuleVers
 		ModPathMap: modPathMap,
 		ModInfoMap: modInfoMap,
 	}, nil
+}
+
+// NewModuleVersioning returns a ModuleVersioning struct from a versioning file and repo root.
+func NewModuleVersioning(versioningFilename string, repoRoot string) (ModuleVersioning, error) {
+	return NewModuleVersioningWithIgnoreExcluded(versioningFilename, repoRoot, false)
 }

--- a/multimod/internal/common/versions.go
+++ b/multimod/internal/common/versions.go
@@ -33,6 +33,7 @@ const (
 type versionConfig struct {
 	ModuleSets      ModuleSetMap `mapstructure:"module-sets"`
 	ExcludedModules []ModulePath `mapstructure:"excluded-modules"`
+	ignoreExcluded  bool
 }
 
 // excludedModules functions as a set containing all module paths that are excluded
@@ -117,7 +118,7 @@ func (versionCfg versionConfig) buildModuleMap() (ModuleInfoMap, error) {
 			}
 
 			// Check if module is in excluded modules section
-			if versionCfg.shouldExcludeModule(modPath) {
+			if !versionCfg.ignoreExcluded && versionCfg.shouldExcludeModule(modPath) {
 				return nil, fmt.Errorf("module %v is an excluded module and should not be versioned", modPath)
 			}
 			modMap[modPath] = ModuleInfo{setName, moduleSet.Version}
@@ -129,6 +130,10 @@ func (versionCfg versionConfig) buildModuleMap() (ModuleInfoMap, error) {
 
 // getExcludedModules returns if a given module path is listed in the excluded modules section of a versioning file.
 func (versionCfg versionConfig) shouldExcludeModule(modPath ModulePath) bool {
+	if versionCfg.ignoreExcluded {
+		return false
+	}
+
 	excludedModules := versionCfg.getExcludedModules()
 	_, exists := excludedModules[modPath]
 
@@ -138,6 +143,9 @@ func (versionCfg versionConfig) shouldExcludeModule(modPath ModulePath) bool {
 // getExcludedModules returns a map structure containing all excluded module paths as keys and empty values.
 func (versionCfg versionConfig) getExcludedModules() excludedModulesSet {
 	excludedModules := make(excludedModulesSet)
+	if versionCfg.ignoreExcluded {
+		return excludedModules
+	}
 	// add all excluded modules to the excludedModulesSet
 	for _, mod := range versionCfg.ExcludedModules {
 		excludedModules[mod] = struct{}{}

--- a/multimod/internal/common/versions.go
+++ b/multimod/internal/common/versions.go
@@ -118,7 +118,7 @@ func (versionCfg versionConfig) buildModuleMap() (ModuleInfoMap, error) {
 			}
 
 			// Check if module is in excluded modules section
-			if !versionCfg.ignoreExcluded && versionCfg.shouldExcludeModule(modPath) {
+			if versionCfg.shouldExcludeModule(modPath) {
 				return nil, fmt.Errorf("module %v is an excluded module and should not be versioned", modPath)
 			}
 			modMap[modPath] = ModuleInfo{setName, moduleSet.Version}

--- a/multimod/internal/sync/sync.go
+++ b/multimod/internal/sync/sync.go
@@ -27,7 +27,7 @@ import (
 	"go.opentelemetry.io/build-tools/multimod/internal/common"
 )
 
-func Run(myVersioningFile string, otherVersioningFile string, otherRepoRoot string, otherModuleSetNames []string, otherVersionCommit string, allModuleSets bool, skipModTidy bool) {
+func Run(myVersioningFile string, otherVersioningFile string, otherRepoRoot string, otherModuleSetNames []string, otherVersionCommit string, allModuleSets bool, skipModTidy bool, ignoreExludedModules bool) {
 	myRepoRoot, err := repo.FindRoot()
 	if err != nil {
 		log.Fatalf("unable to find repo root: %v", err)
@@ -51,7 +51,7 @@ func Run(myVersioningFile string, otherVersioningFile string, otherRepoRoot stri
 	}
 
 	for _, moduleSetName := range otherModuleSetNames {
-		s, err := newSync(myVersioningFile, otherVersioningFile, moduleSetName, myRepoRoot, otherVersionCommit)
+		s, err := newSync(myVersioningFile, otherVersioningFile, moduleSetName, myRepoRoot, otherVersionCommit, ignoreExludedModules)
 		if err != nil {
 			log.Fatalf("error creating new sync struct: %v", err)
 		}
@@ -98,13 +98,13 @@ type sync struct {
 	client                   *http.Client
 }
 
-func newSync(myVersioningFilename, otherVersioningFilename, modSetToUpdate, myRepoRoot string, otherVersionCommit string) (sync, error) {
+func newSync(myVersioningFilename, otherVersioningFilename, modSetToUpdate, myRepoRoot string, otherVersionCommit string, ignoreExcluded bool) (sync, error) {
 	otherModuleSet, err := common.GetModuleSet(modSetToUpdate, otherVersioningFilename)
 	if err != nil {
 		return sync{}, fmt.Errorf("error creating new sync struct: %w", err)
 	}
 
-	myModVersioning, err := common.NewModuleVersioning(myVersioningFilename, myRepoRoot)
+	myModVersioning, err := common.NewModuleVersioningWithIgnoreExcluded(myVersioningFilename, myRepoRoot, ignoreExcluded)
 	if err != nil {
 		return sync{}, fmt.Errorf("could not get my ModuleVersioning: %w", err)
 	}

--- a/multimod/internal/sync/sync.go
+++ b/multimod/internal/sync/sync.go
@@ -27,7 +27,7 @@ import (
 	"go.opentelemetry.io/build-tools/multimod/internal/common"
 )
 
-func Run(myVersioningFile string, otherVersioningFile string, otherRepoRoot string, otherModuleSetNames []string, otherVersionCommit string, allModuleSets bool, skipModTidy bool, ignoreExludedModules bool) {
+func Run(myVersioningFile string, otherVersioningFile string, otherRepoRoot string, otherModuleSetNames []string, otherVersionCommit string, allModuleSets bool, skipModTidy bool) {
 	myRepoRoot, err := repo.FindRoot()
 	if err != nil {
 		log.Fatalf("unable to find repo root: %v", err)
@@ -51,7 +51,7 @@ func Run(myVersioningFile string, otherVersioningFile string, otherRepoRoot stri
 	}
 
 	for _, moduleSetName := range otherModuleSetNames {
-		s, err := newSync(myVersioningFile, otherVersioningFile, moduleSetName, myRepoRoot, otherVersionCommit, ignoreExludedModules)
+		s, err := newSync(myVersioningFile, otherVersioningFile, moduleSetName, myRepoRoot, otherVersionCommit, allModuleSets)
 		if err != nil {
 			log.Fatalf("error creating new sync struct: %v", err)
 		}

--- a/multimod/internal/sync/sync_test.go
+++ b/multimod/internal/sync/sync_test.go
@@ -342,7 +342,7 @@ func TestUpdateAllGoModFiles(t *testing.T) {
 	testCases := []struct {
 		modSetName             string
 		expectedOutputModFiles map[string][]byte
-		ignoreExcluded         bool
+		allModules             bool
 	}{
 		{
 			modSetName: "other-mod-set-1",
@@ -503,7 +503,7 @@ func TestUpdateAllGoModFiles(t *testing.T) {
 					"go.opentelemetry.io/other/test/test1 v1.0.0-old\n" +
 					")"),
 			},
-			ignoreExcluded: true,
+			allModules: true,
 		},
 	}
 
@@ -562,7 +562,7 @@ func TestUpdateAllGoModFiles(t *testing.T) {
 				tc.modSetName,
 				tmpRootDir,
 				"",
-				tc.ignoreExcluded,
+				tc.allModules,
 			)
 			require.NoError(t, err)
 


### PR DESCRIPTION
This allows users of the `sync` command to sync all modules in a monorepo, including those listed in the excluded-modules. This is useful for repositories where some modules may not yet be ready for releasing (therefore listed under excluded-modules) but their dependencies still need to be managed via multimod.