### PR TITLE
[chloggen] Update permissions of the generated files

### DIFF
--- a/.chloggen/permissions-with-no-execution.yaml
+++ b/.chloggen/permissions-with-no-execution.yaml
@@ -5,7 +5,7 @@ change_type: bug_fix
 component: chloggen
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: Updates generated files permissions from 0755 to 0644
+note: Change generated files permissions from 0755 to 0644.
 
 # One or more tracking issues related to the change
 issues: [457]

--- a/.chloggen/permissions-with-no-execution.yaml
+++ b/.chloggen/permissions-with-no-execution.yaml
@@ -5,7 +5,7 @@ change_type: bug_fix
 component: chloggen
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: Change generated files permissions from 0755 to 0644.
+note: change generated files permissions from 0755 to 0644
 
 # One or more tracking issues related to the change
 issues: [457]

--- a/.chloggen/permissions-with-no-execution.yaml
+++ b/.chloggen/permissions-with-no-execution.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type:
+
+# The name of the component, or a single word describing the area of concern, (e.g. crosslink)
+component:
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note:
+
+# One or more tracking issues related to the change
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/.chloggen/permissions-with-no-execution.yaml
+++ b/.chloggen/permissions-with-no-execution.yaml
@@ -1,14 +1,14 @@
 # One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
-change_type:
+change_type: bug_fix
 
 # The name of the component, or a single word describing the area of concern, (e.g. crosslink)
-component:
+component: chloggen
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note:
+note: Updates generated files permissions from 0755 to 0644
 
 # One or more tracking issues related to the change
-issues: []
+issues: [457]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/chloggen/cmd/new.go
+++ b/chloggen/cmd/new.go
@@ -46,7 +46,7 @@ func newCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			err = os.WriteFile(pathWithExt, templateBytes, os.FileMode(0755))
+			err = os.WriteFile(pathWithExt, templateBytes, os.FileMode(0644))
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
## Contributions
When you use `chloggen new --config template.yaml --filename contribution.yaml` the generated file
has `0755` permission. Thus, it generates `yaml` files with **Execution** permission.

Maybe you folks have a purpose for doing it. Although, I didn't find any explanation for it. 
Therefore, from my perspective, it seems to be a "bug". Please close this PR in case I am wrong. 

This Pull Request updates the code in order to use the permission `0644` where we have:
* User: Write, Read, No Execution
* Group: No Write, Read, No Execution
* Others: No Write, Read, No Execution

## Context 
I was writing [this Pull Request](https://github.com/open-telemetry/opentelemetry-collector/pull/8955) to Open Telemetry Collectors and realized that this tool (`chloggen`) was creating executable files under `.chloggen/`directory which seemed strange to me. 