### PR TITLE
multimod: Fix tagging on Windows

### DIFF
--- a/.chloggen/multimod-fix-tagging-on-windows.yaml
+++ b/.chloggen/multimod-fix-tagging-on-windows.yaml
@@ -1,0 +1,17 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. crosslink)
+component: multimod
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix tagging on Windows
+
+# One or more tracking issues related to the change
+issues: [464]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  This fixes the issue of `multimod tag` failing on Windows.

--- a/multimod/internal/common/tools.go
+++ b/multimod/internal/common/tools.go
@@ -79,7 +79,7 @@ func updateGoModVersions(modFilePath ModuleFilePath, newModPaths []ModulePath, n
 	}
 
 	// once all module versions have been updated, overwrite the go.mod file
-	if err := os.WriteFile(string(modFilePath), newGoModFile, 0600); err != nil {
+	if err := os.WriteFile(string(modFilePath), newGoModFile, 0o600); err != nil {
 		return fmt.Errorf("error overwriting go.mod file: %w", err)
 	}
 
@@ -87,7 +87,7 @@ func updateGoModVersions(modFilePath ModuleFilePath, newModPaths []ModulePath, n
 }
 
 func replaceModVersion(modPath ModulePath, version string, newGoModFile []byte) ([]byte, error) {
-	oldVersionRegex := `(?m:` + filePathToRegex(string(modPath)) + `\s+` + SemverRegex + `(\s*\/\/\s*indirect\s*?)?$)`
+	oldVersionRegex := `(?m:` + modulePathToRegex(modPath) + `\s+` + SemverRegex + `(\s*\/\/\s*indirect\s*?)?$)`
 	r, err := regexp.Compile(oldVersionRegex)
 	if err != nil {
 		return nil, fmt.Errorf("error compiling regex: %w", err)
@@ -116,9 +116,11 @@ func UpdateGoModFiles(modFilePaths []ModuleFilePath, newModPaths []ModulePath, n
 	return nil
 }
 
-func filePathToRegex(fpath string) string {
-	quotedMeta := regexp.QuoteMeta(fpath)
-	replacedSlashes := strings.ReplaceAll(quotedMeta, string(filepath.Separator), `\/`)
+// modulePathToRegex escapes all regular expression characters and replaces all slashes with escaped slashes.
+// ModulePath is expected to only have forward slashes, even on Windows.
+func modulePathToRegex(fpath ModulePath) string {
+	quotedMeta := regexp.QuoteMeta(string(fpath))
+	replacedSlashes := strings.ReplaceAll(quotedMeta, "/", `\/`)
 	return replacedSlashes
 }
 

--- a/multimod/internal/common/tools_test.go
+++ b/multimod/internal/common/tools_test.go
@@ -139,9 +139,9 @@ func TestUpdateGoModVersions(t *testing.T) {
 	}
 }
 
-func TestFilePathToRegex(t *testing.T) {
+func TestModulePathToRegex(t *testing.T) {
 	testCases := []struct {
-		fpath    string
+		fpath    ModulePath
 		expected string
 	}{
 		{
@@ -155,7 +155,7 @@ func TestFilePathToRegex(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		actual := filePathToRegex(tc.fpath)
+		actual := modulePathToRegex(tc.fpath)
 
 		assert.Equal(t, tc.expected, actual)
 	}


### PR DESCRIPTION
Fixes #464 

- `moduleFilePathToTagName()` produces the following on Windows due to Windows file path using backslashes instead of slashes.
	```
	could not retrieve tag names from module paths: could not convert module file paths to tag names: could not convert module file path to tag name: modFilePath C:\...\test\test1\go.mod not contained in repo with root C:\...\
	```

- `filePathToRegex()` failing as `filepath.Separator()` in Windows is a backslash instead of the expected slash.

`multimod` unit test now passes on Windows with this PR