### PR TITLE
[crosslink] add --skip flag

### DIFF
--- a/.chloggen/codeboten_crosslink-skip.yaml
+++ b/.chloggen/codeboten_crosslink-skip.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. crosslink)
+component: crosslink
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Add `--skip` flag to ignore specified go modules"
+
+# One or more tracking issues related to the change
+issues: [480]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/crosslink/README.md
+++ b/crosslink/README.md
@@ -114,6 +114,24 @@ Multiple calls to exclude can also be made
     --exclude=example.com/foo/bar/modC \
     --exclude=example.com/foo/bar/modJ,example.com/modZ
 
+### --skip
+
+Skip is a set of go.mod files that will not be changed by crosslink.
+It is expected that a list of comma-separated values will be provided in one or
+multiple calls to skip. These go.mod files will be left unchanged by
+crosslink. An example where using this may be appropriate is to avoid
+adding replace statements in a go module that is intended to be installed
+via `go install`.
+
+A single call to skip
+
+    crosslink --skip cmd/example/go.mod,cmd/example2/go.mod,
+
+Multiple calls to exclude can also be made
+
+    crosslink --skip cmd/example/go.mod \
+    --skip cmd/example2/go.mod
+
 ### –-verbose / -v
 
 Verbose enables crosslink to log all replace (destructive and non-destructive) and

--- a/crosslink/cmd/root.go
+++ b/crosslink/cmd/root.go
@@ -141,7 +141,7 @@ func init() {
 	comCfg.rootCommand.PersistentFlags().BoolVarP(&comCfg.runConfig.Verbose, "verbose", "v", false, "verbose output")
 	comCfg.rootCommand.Flags().StringSliceVar(&comCfg.excludeFlags, "exclude", []string{}, "list of comma separated go modules that crosslink will ignore in operations."+
 		"multiple calls of --exclude can be made")
-	comCfg.rootCommand.Flags().StringSliceVar(&comCfg.skipFlags, "skip", []string{}, "list of comma separated go.mod files that crosslink will ignore in this repo."+
+	comCfg.rootCommand.Flags().StringSliceVar(&comCfg.skipFlags, "skip", []string{}, "list of comma separated go.mod files that will not be affected (changed) by crosslink."+
 		"multiple calls of --skip can be made")
 	comCfg.rootCommand.Flags().BoolVar(&comCfg.runConfig.Overwrite, "overwrite", false, "overwrite flag allows crosslink to make destructive (replacing or updating) actions to existing go.mod files")
 	comCfg.rootCommand.Flags().BoolVarP(&comCfg.runConfig.Prune, "prune", "p", false, "enables pruning operations on all go.mod files inside root repository")

--- a/crosslink/cmd/root.go
+++ b/crosslink/cmd/root.go
@@ -31,6 +31,7 @@ import (
 type commandConfig struct {
 	runConfig    cl.RunConfig
 	excludeFlags []string
+	skipFlags    []string
 	rootCommand  cobra.Command
 	pruneCommand cobra.Command
 	workCommand  cobra.Command
@@ -43,6 +44,7 @@ func newCommandConfig() *commandConfig {
 
 	preRunSetup := func(cmd *cobra.Command, args []string) error {
 		c.runConfig.ExcludedPaths = transformExclude(c.excludeFlags)
+		c.runConfig.SkippedPaths = transformExclude(c.skipFlags)
 
 		if c.runConfig.RootPath == "" {
 			rp, err := repo.FindRoot()
@@ -139,6 +141,8 @@ func init() {
 	comCfg.rootCommand.PersistentFlags().BoolVarP(&comCfg.runConfig.Verbose, "verbose", "v", false, "verbose output")
 	comCfg.rootCommand.Flags().StringSliceVar(&comCfg.excludeFlags, "exclude", []string{}, "list of comma separated go modules that crosslink will ignore in operations."+
 		"multiple calls of --exclude can be made")
+	comCfg.rootCommand.Flags().StringSliceVar(&comCfg.skipFlags, "skip", []string{}, "list of comma separated go.mod files that crosslink will ignore in this repo."+
+		"multiple calls of --skip can be made")
 	comCfg.rootCommand.Flags().BoolVar(&comCfg.runConfig.Overwrite, "overwrite", false, "overwrite flag allows crosslink to make destructive (replacing or updating) actions to existing go.mod files")
 	comCfg.rootCommand.Flags().BoolVarP(&comCfg.runConfig.Prune, "prune", "p", false, "enables pruning operations on all go.mod files inside root repository")
 	comCfg.pruneCommand.Flags().StringSliceVar(&comCfg.excludeFlags, "exclude", []string{}, "list of comma separated go modules that crosslink will ignore in operations."+

--- a/crosslink/cmd/root_test.go
+++ b/crosslink/cmd/root_test.go
@@ -190,7 +190,7 @@ func TestPreRun(t *testing.T) {
 			err = testPreRun(&comCfg.rootCommand, nil)
 			assert.NoError(t, err, "Pre Run returned error")
 
-			if diff := cmp.Diff(test.expectedConfig, comCfg.runConfig, cmpopts.IgnoreFields(cl.RunConfig{}, "Logger", "ExcludedPaths")); diff != "" {
+			if diff := cmp.Diff(test.expectedConfig, comCfg.runConfig, cmpopts.IgnoreFields(cl.RunConfig{}, "Logger", "ExcludedPaths", "SkippedPaths")); diff != "" {
 				t.Errorf("TestCase: %s \n Config{} mismatch (-want +got):\n%s", test.testName, diff)
 			}
 		})

--- a/crosslink/internal/config.go
+++ b/crosslink/internal/config.go
@@ -37,6 +37,7 @@ type RunConfig struct {
 	RootPath      string
 	Verbose       bool
 	ExcludedPaths map[string]struct{}
+	SkippedPaths  map[string]struct{}
 	Overwrite     bool
 	Prune         bool
 	GoVersion     string

--- a/crosslink/internal/graph.go
+++ b/crosslink/internal/graph.go
@@ -31,6 +31,10 @@ func buildDepedencyGraph(rc RunConfig, rootModulePath string) (map[string]*modul
 	moduleMap := make(map[string]*moduleInfo)
 
 	err := forGoModules(rc.Logger, rc.RootPath, func(path string) error {
+		if _, ok := rc.SkippedPaths[path]; ok {
+			rc.Logger.Debug("skipping", zap.String("path", path))
+			return nil
+		}
 		fullPath := filepath.Join(rc.RootPath, path)
 		modFile, err := os.ReadFile(filepath.Clean(fullPath))
 		if err != nil {

--- a/crosslink/internal/mock_test_data/testSkip/gomod
+++ b/crosslink/internal/mock_test_data/testSkip/gomod
@@ -1,0 +1,14 @@
+module go.opentelemetry.io/build-tools/crosslink/testroot
+
+go 1.20
+
+require go.opentelemetry.io/build-tools/crosslink/testroot/testA v1.0.0
+
+// should not be replaced or overwritten
+replace go.opentelemetry.io/build-tools/crosslink/testroot/testA => ./testA
+
+// included in exclude slice and should be ignored
+// replace go.opentelemetry.io/build-tools/crosslink/testroot/testB => ./testB"
+
+// should not be pruned
+replace go.opentelemetry.io/build-tools/excludeme => ../excludeme

--- a/crosslink/internal/mock_test_data/testSkip/testA/gomod
+++ b/crosslink/internal/mock_test_data/testSkip/testA/gomod
@@ -1,0 +1,7 @@
+module go.opentelemetry.io/build-tools/crosslink/testroot/testA
+
+go 1.20
+
+require go.opentelemetry.io/build-tools/crosslink/testroot/testB v1.0.0
+
+replace go.opentelemetry.io/build-tools/crosslink/testroot/testB => ../testB

--- a/crosslink/internal/mock_test_data/testSkip/testB/gomod
+++ b/crosslink/internal/mock_test_data/testSkip/testB/gomod
@@ -1,0 +1,3 @@
+module go.opentelemetry.io/build-tools/crosslink/testroot/testB
+
+go 1.20


### PR DESCRIPTION
This allows modules in monorepos to opt out of crosslink. This will be used in mdatagen in the Collector core repo for example, where mdatagen has dependencies on internal collector modules, but we don't want to use replace statements as it breaks the ability to `go install` mdatagen

Related to https://github.com/open-telemetry/opentelemetry-collector/issues/9281