### PR TITLE
multimod: Fix to log 'Using versioning file' to stderr instead of stdout

### DIFF
--- a/.chloggen/multimod-print-using-to-stderr.yaml
+++ b/.chloggen/multimod-print-using-to-stderr.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. crosslink)
+component: multimod
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix to log 'Using versioning file' to stderr instead of stdout
+
+# One or more tracking issues related to the change
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/Makefile
+++ b/Makefile
@@ -196,7 +196,7 @@ REMOTE?=git@github.com:open-telemetry/opentelemetry-go-build-tools.git
 .PHONY: push-tags
 push-tags: | $(MULTIMOD)
 	$(MULTIMOD) verify
-	set -e; for tag in `$(MULTIMOD) tag -m tools -c ${COMMIT} --print-tags | grep -v "Using" `; do \
+	set -e; for tag in `$(MULTIMOD) tag -m tools -c ${COMMIT} --print-tags ; do \
 		echo "pushing tag $${tag}"; \
 		git push ${REMOTE} $${tag}; \
 	done;

--- a/multimod/cmd/prerelease.go
+++ b/multimod/cmd/prerelease.go
@@ -15,7 +15,6 @@
 package cmd
 
 import (
-	"fmt"
 	"log"
 
 	"github.com/spf13/cobra"
@@ -55,7 +54,7 @@ var prereleaseCmd = &cobra.Command{
 		}
 	},
 	Run: func(*cobra.Command, []string) {
-		fmt.Println("Using versioning file", versioningFile)
+		log.Println("Using versioning file", versioningFile)
 
 		prerelease.Run(versioningFile, moduleSetNames, allModuleSets, skipGoModTidy, commitToDifferentBranch)
 	},

--- a/multimod/cmd/sync.go
+++ b/multimod/cmd/sync.go
@@ -56,7 +56,7 @@ var syncCmd = &cobra.Command{
 		}
 	},
 	Run: func(*cobra.Command, []string) {
-		fmt.Println("Using versioning file", versioningFile)
+		log.Println("Using versioning file", versioningFile)
 
 		if otherVersioningFile == "" {
 			otherVersioningFile = filepath.Join(otherRepoRoot,

--- a/multimod/cmd/tag.go
+++ b/multimod/cmd/tag.go
@@ -15,7 +15,6 @@
 package cmd
 
 import (
-	"fmt"
 	"log"
 
 	"github.com/spf13/cobra"
@@ -38,7 +37,7 @@ var tagCmd = &cobra.Command{
 - Creates new Git tags for all modules being updated.
 - If tagging fails in the middle of the script, the recently created tags will be deleted.`,
 	Run: func(*cobra.Command, []string) {
-		fmt.Println("Using versioning file", versioningFile)
+		log.Println("Using versioning file", versioningFile)
 
 		tag.Run(versioningFile, moduleSetName, commitHash, deleteModuleSetTags, printTags)
 	},

--- a/multimod/cmd/verify.go
+++ b/multimod/cmd/verify.go
@@ -15,7 +15,6 @@
 package cmd
 
 import (
-	"fmt"
 	"log"
 
 	"github.com/spf13/cobra"
@@ -34,7 +33,7 @@ var verifyCmd = &cobra.Command{
 - Script warns if any stable modules depend on any unstable modules.
 `,
 	Run: func(*cobra.Command, []string) {
-		fmt.Println("Using versioning file", versioningFile)
+		log.Println("Using versioning file", versioningFile)
 
 		verify.Run(versioningFile)
 	},


### PR DESCRIPTION
This will to get rid of things like:
- https://github.com/open-telemetry/opentelemetry-collector/blob/4ae8d2bcd5ae2e72280fb6af7e9402b7b6e7c6cb/Makefile#L402
- https://github.com/signalfx/splunk-otel-go/pull/2994