### PR TITLE
Fix all lint deprecations

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -18,9 +18,10 @@ run:
   # from this option's value (see skip-dirs-use-default).
   skip-dirs:
 
-  # default is true. Enables skipping of directories:
-  #   vendor$, third_party$, testdata$, examples$, Godeps$, builtin$
-  skip-dirs-use-default: false
+  issues:
+    # default is true. Enables skipping of directories:
+    #   vendor$, third_party$, testdata$, examples$, Godeps$, builtin$
+    exclude-dirs-use-default: false
 
   # which files to skip: they will be analyzed, but issues from them
   # won't be reported. Default value is empty list, but there is
@@ -45,7 +46,7 @@ run:
 # output configuration options
 output:
   # colored-line-number|line-number|json|tab|checkstyle|code-climate, default is "colored-line-number"
-  format: colored-line-number
+  formats: colored-line-number
 
   # print lines of code with issue, default is true
   print-issued-lines: true
@@ -57,7 +58,7 @@ output:
 linters-settings:
   govet:
     # report about shadowed variables
-    check-shadowing: true
+    shadow: true
 
     # settings per analyzer
     settings:


### PR DESCRIPTION
> level=warning msg="[config_reader] The configuration option `run.skip-dirs-use-default` is deprecated, please use `issues.exclude-dirs-use-default`."
level=warning msg="[config_reader] The configuration option `output.format` is deprecated, please use `output.formats`"
level=warning msg="[config_reader] The configuration option `linters.govet.check-shadowing` is deprecated. Please enable `shadow` instead, if you are not using `enable-all`."