### PR TITLE
refactor: fix gosec linter G301 issue

### DIFF
--- a/chloggen/internal/chlog/entry_test.go
+++ b/chloggen/internal/chlog/entry_test.go
@@ -256,7 +256,7 @@ func TestEntry(t *testing.T) {
 func TestReadDeleteEntries(t *testing.T) {
 	tempDir := t.TempDir()
 	entriesDir := filepath.Join(tempDir, config.DefaultEntriesDir)
-	require.NoError(t, os.Mkdir(entriesDir, os.ModePerm))
+	require.NoError(t, os.Mkdir(entriesDir, 0750))
 
 	entryA := Entry{
 		ChangeLogs: []string{"foo"},

--- a/internal/repo/repo_test.go
+++ b/internal/repo/repo_test.go
@@ -50,7 +50,7 @@ func setupGoMod(t *testing.T, dirs []string) string {
 
 	paths := append([]string{root}, prepend(root, dirs...)...)
 	for _, d := range paths {
-		require.NoError(t, os.MkdirAll(d, os.ModePerm))
+		require.NoError(t, os.MkdirAll(d, 0750))
 		goMod := filepath.Join(d, "go.mod")
 		f, err := os.Create(filepath.Clean(goMod))
 		require.NoError(t, err)
@@ -65,7 +65,7 @@ func TestFindModules(t *testing.T) {
 	dirs := []string{"a", "a/b", "c"}
 	root := setupGoMod(t, dirs)
 	// Add a non-module dir.
-	require.NoError(t, os.MkdirAll(filepath.Join(root, "tools"), os.ModePerm))
+	require.NoError(t, os.MkdirAll(filepath.Join(root, "tools"), 0750))
 
 	got, err := FindModules(root, nil)
 	require.NoError(t, err)
@@ -114,7 +114,7 @@ func setupDocker(t *testing.T, layout []*fPath) string {
 
 	}
 	for _, path := range layout {
-		require.NoError(t, os.MkdirAll(path.dir, os.ModePerm))
+		require.NoError(t, os.MkdirAll(path.dir, 0750))
 
 		dFile := filepath.Join(path.dir, path.file)
 		f, err := os.Create(filepath.Clean(dFile))
@@ -134,7 +134,7 @@ func TestFindDockerfiles(t *testing.T) {
 	}
 	root := setupDocker(t, layout)
 	// Add an empty dir.
-	require.NoError(t, os.MkdirAll(filepath.Join(root, "tools"), os.ModePerm))
+	require.NoError(t, os.MkdirAll(filepath.Join(root, "tools"), 0750))
 
 	got, err := FindFilePatternDirs(root, "*Dockerfile*", nil)
 	require.NoError(t, err)
@@ -159,7 +159,7 @@ func TestFindDockerfilesIgnore(t *testing.T) {
 	}
 	root := setupDocker(t, layout)
 	// Add an empty dir.
-	require.NoError(t, os.MkdirAll(filepath.Join(root, "tools"), os.ModePerm))
+	require.NoError(t, os.MkdirAll(filepath.Join(root, "tools"), 0750))
 
 	got, err := FindFilePatternDirs(root, "*Dockerfile*", []string{"a/b", "aa/b?", "c"})
 	require.NoError(t, err)


### PR DESCRIPTION
The G301 rule was updated to check for `os.ModePerm` in v1.58.2: https://github.com/securego/gosec/pull/1138.

This unblocks the upgrade of Go linter from v1.58.1 to a later version.

Example of a failure on linter upgrade PR https://github.com/open-telemetry/opentelemetry-go-build-tools/pull/574:
- https://github.com/open-telemetry/opentelemetry-go-build-tools/actions/runs/10355977808/job/28664809719