### PR TITLE
[multimod] Improve error message when Go proxy misbehaves

### DIFF
--- a/.chloggen/mx-psi_better-multimod-errors.yaml
+++ b/.chloggen/mx-psi_better-multimod-errors.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. crosslink)
+component: multimod
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Improve error message when the Go proxy misbehaves
+
+# One or more tracking issues related to the change
+issues: [610]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/multimod/internal/sync/sync.go
+++ b/multimod/internal/sync/sync.go
@@ -128,10 +128,16 @@ func (s sync) parseVersionInfo(pkg, tag string) (string, error) {
 	if err != nil {
 		return "", nil
 	}
+
+	if res.StatusCode >= 400 {
+		return "", fmt.Errorf("request to proxy for package %q at version %q failed with status %d (%s): %s",
+			pkg, tag, res.StatusCode, res.Status, string(body))
+	}
+
 	var data struct{ Version string }
 	err = json.Unmarshal(body, &data)
 	if err != nil {
-		return "", fmt.Errorf("failed to unmarshal response: %w", err)
+		return "", fmt.Errorf("failed to unmarshal response for package %q at version %q: %w", pkg, tag, err)
 	}
 
 	return fmt.Sprint(data.Version), err

--- a/multimod/internal/sync/sync_test.go
+++ b/multimod/internal/sync/sync_test.go
@@ -253,6 +253,21 @@ func TestUpdateAllGoModFilesWithCommitHash(t *testing.T) {
 					}
 				}),
 			},
+			expectedErr: "request to proxy for package \"go.opentelemetry.io/other/test/test1\" at version \"main\" failed with status 500",
+		},
+
+		{
+			modSetName: "other-mod-set-1",
+			commit:     "main",
+			client: &http.Client{
+				Transport: roundTripFunc(func(*http.Request) *http.Response {
+					return &http.Response{
+						StatusCode: 200,
+						Body:       io.NopCloser(bytes.NewBufferString(`invalid message`)),
+						Header:     make(http.Header),
+					}
+				}),
+			},
 			expectedErr: "failed to unmarshal response",
 		},
 	}


### PR DESCRIPTION
- Check status code of reply from Go proxy and fail if status code is 4xx or 5xx.
- Add information about package and tag that caused the failure