### PR TITLE
fix: set default output of chloggen to stdout

### DIFF
--- a/.chloggen/mowies-fix-chloggen-output.yaml
+++ b/.chloggen/mowies-fix-chloggen-output.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. crosslink)
+component: chloggen
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix bug that directed all output to stderr
+
+# One or more tracking issues related to the change
+issues: [612]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/chloggen/cmd/root.go
+++ b/chloggen/cmd/root.go
@@ -34,6 +34,7 @@ func rootCmd() *cobra.Command {
 		Short: "Updates CHANGELOG.MD to include all new changes",
 		Long:  `chloggen is a tool used to automate the generation of CHANGELOG files using individual yaml files as the source.`,
 	}
+	cmd.SetOut(os.Stdout)
 	cmd.PersistentFlags().StringVar(&configFile, "config", "", "(optional) chloggen config file")
 	cmd.AddCommand(newCmd())
 	cmd.AddCommand(updateCmd())


### PR DESCRIPTION
Fixes #611

This PR sets the default output for `chloggen` to stdout as it would be set to stderr otherwise which has all kinds of issues that follow in the usage of the tool downstream.