### PR TITLE
Pin markdown-link-check to 3.12.2

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -74,7 +74,7 @@ jobs:
       - name: Render .chloggen changelog entries
         run: make chlog-preview > changelog_preview.md
       - name: Install markdown-link-check
-        run: npm install -g markdown-link-check
+        run: npm install -g markdown-link-check@3.12.2
       - name: Run markdown-link-check
         run: |
           markdown-link-check \


### PR DESCRIPTION
As the more recent versions are broken, and falsely fail the build.

See https://github.com/tcort/markdown-link-check/issues/369
Related: https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/36223