### PR TITLE
Fix go version in go.mod files

### DIFF
--- a/checkfile/go.mod
+++ b/checkfile/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/build-tools/checkfile
 
-go 1.22
+go 1.22.0
 
 require github.com/stretchr/testify v1.10.0
 

--- a/chloggen/go.mod
+++ b/chloggen/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/build-tools/chloggen
 
-go 1.22
+go 1.22.0
 
 require (
 	github.com/spf13/cobra v1.8.1

--- a/gotmpl/go.mod
+++ b/gotmpl/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/build-tools/gotmpl
 
-go 1.22
+go 1.22.0
 
 require (
 	github.com/spf13/pflag v1.0.5

--- a/issuegenerator/go.mod
+++ b/issuegenerator/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/build-tools/issuegenerator
 
-go 1.22
+go 1.22.0
 
 require (
 	github.com/google/go-github v17.0.0+incompatible


### PR DESCRIPTION
As of Go 1.21, toolchain versions [must use the 1.N.P syntax](https://go.dev/doc/toolchain#version).

These `go.mod` file versions are causing warnings and failures for our [code scanning](https://github.com/open-telemetry/opentelemetry-go-build-tools/security/code-scanning/tools/CodeQL/status/configurations/actions-FZTWS5DIOVRC653POJVWM3DPO5ZS6Y3PMRSXC3BNMFXGC3DZONUXGLTZNVWA/aaae0317b64670efe4847cc4a5d8cc1ef1040c5bf8f8382c70dfc564dda7cb86).