### PR TITLE
Exclude githubgen from released modules

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -21,7 +21,6 @@ module-sets:
       - go.opentelemetry.io/build-tools/chloggen
       - go.opentelemetry.io/build-tools/crosslink
       - go.opentelemetry.io/build-tools/dbotconf
-      - go.opentelemetry.io/build-tools/githubgen
       - go.opentelemetry.io/build-tools/gotmpl
       - go.opentelemetry.io/build-tools/issuegenerator
       - go.opentelemetry.io/build-tools/multimod
@@ -29,3 +28,4 @@ module-sets:
 
 excluded-modules:
   - go.opentelemetry.io/build-tools/internal/tools
+  - go.opentelemetry.io/build-tools/githubgen


### PR DESCRIPTION
This excludes githubgen from the released modules, so 0.16.0 can be cut (https://github.com/open-telemetry/opentelemetry-go-build-tools/pull/656) before the additional work on that module is finished (https://github.com/open-telemetry/opentelemetry-go-build-tools/pull/655).