### PR TITLE
Add `--skip` flag to `crosslink tidylist`

### DIFF
--- a/.chloggen/crosslink-tidy-v2.yaml
+++ b/.chloggen/crosslink-tidy-v2.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: 'enhancement'
+
+# The name of the component, or a single word describing the area of concern, (e.g. crosslink)
+component: crosslink
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Added `--skip` flag to `crosslink tidylist` subcommand
+
+# One or more tracking issues related to the change
+issues: [662]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/crosslink/cmd/root.go
+++ b/crosslink/cmd/root.go
@@ -166,6 +166,8 @@ func init() {
 	comCfg.workCommand.Flags().StringVar(&comCfg.runConfig.GoVersion, "go", "1.22", "Go version applied when new go.work file is created")
 	comCfg.tidyListCommand.Flags().StringVar(&comCfg.runConfig.AllowCircular, "allow-circular", "", "path to list of go modules that are allowed to have circular dependencies")
 	comCfg.tidyListCommand.Flags().BoolVar(&comCfg.runConfig.Validate, "validate", false, "enables brute force validation of the tidy schedule")
+	comCfg.tidyListCommand.Flags().StringSliceVar(&comCfg.skipFlags, "skip", []string{}, "list of comma separated go.mod files that will be ignored by crosslink. "+
+		"multiple calls of --skip can be made")
 }
 
 // transform array slice into map

--- a/crosslink/internal/mock_test_data/testTidyListOrder/gomod
+++ b/crosslink/internal/mock_test_data/testTidyListOrder/gomod
@@ -1,0 +1,3 @@
+module go.opentelemetry.io/build-tools/crosslink/testroot
+
+go 1.20

--- a/crosslink/internal/mock_test_data/testTidyListOrder/testA/gomod
+++ b/crosslink/internal/mock_test_data/testTidyListOrder/testA/gomod
@@ -1,0 +1,5 @@
+module go.opentelemetry.io/build-tools/crosslink/testroot/testA
+
+go 1.20
+
+require go.opentelemetry.io/build-tools/crosslink/testroot/testC v1.0.0

--- a/crosslink/internal/mock_test_data/testTidyListOrder/testB/gomod
+++ b/crosslink/internal/mock_test_data/testTidyListOrder/testB/gomod
@@ -1,0 +1,3 @@
+module go.opentelemetry.io/build-tools/crosslink/testroot/testB
+
+go 1.20

--- a/crosslink/internal/mock_test_data/testTidyListOrder/testC/gomod
+++ b/crosslink/internal/mock_test_data/testTidyListOrder/testC/gomod
@@ -1,0 +1,3 @@
+module go.opentelemetry.io/build-tools/crosslink/testroot/testC
+
+go 1.20

--- a/crosslink/internal/tidylist_test.go
+++ b/crosslink/internal/tidylist_test.go
@@ -65,6 +65,22 @@ func TestTidy(t *testing.T) {
 			},
 			expSched: []string{".", "testC", "testB", "testA", "testB"},
 		},
+		{ // A -> C, B should give CAB (default to alphabetical order when no contraint)
+			name:     "testTidyListOrder",
+			mock:     "testTidyListOrder",
+			config:   func(*RunConfig) {},
+			expSched: []string{".", "testC", "testA", "testB"},
+		},
+		{ // A -> C, B with A skipped should give BC (prune the graph, not just filter the output)
+			name: "testTidyListSkip",
+			mock: "testTidyListOrder",
+			config: func(config *RunConfig) {
+				config.SkippedPaths = map[string]struct{}{
+					"testA/go.mod": {},
+				}
+			},
+			expSched: []string{".", "testB", "testC"},
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {


### PR DESCRIPTION
Integration of `crosslink tidylist` (cf. #642 for context) in collector-contrib encountered [issues](https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/37173), because the output depended on the existence of the `cmd/otelcontribcol` and `cmd/oteltestbedcol`, which are autogenerated and `gitignore`d. I had manually filtered them from the output, but their presence still caused changes to the order of the other modules.

This PR introduces a new `--skip` flag to the `crosslink tidylist` subcommand, similar to the one on the root command, which specifies `go.mod` files that should be entirely ignored by the command (omitted from the output, but also ignored when analyzing the dependency graph). Using this in contrib should fix the non-determinism issue.

I also introduced two new tests to help check the determinism of the tool: one checking that the tool defaults to alphabetical order in the absence of dependency constraints, and one checking that `--skip` works as described above.