### PR TITLE
[chore][githubgen] Remove unnecessary trailing whitespace

### DIFF
--- a/githubgen/codeowners.go
+++ b/githubgen/codeowners.go
@@ -141,7 +141,7 @@ LOOP:
 		for stability := range m.Status.Stability {
 			if stability == unmaintainedStatus {
 				unmaintainedList += key + "/\n"
-				unmaintainedCodeowners += fmt.Sprintf("%s/%s @open-telemetry/collector-contrib-approvers \n", key, strings.Repeat(" ", data.MaxLength-len(key)))
+				unmaintainedCodeowners += fmt.Sprintf("%s/%s @open-telemetry/collector-contrib-approvers\n", key, strings.Repeat(" ", data.MaxLength-len(key)))
 				continue LOOP
 			}
 			if stability == "deprecated" && (m.Status.Codeowners == nil || len(m.Status.Codeowners.Active) == 0) {


### PR DESCRIPTION
Context in https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/37292

Currently, lines generated for unmaintained components in `.github/CODEOWNERS` have a trailing whitespace. This is a whitespace error. This removes the trailing whitespace.