### PR TITLE
Relax the minimum required Go version

### DIFF
--- a/.chloggen/go-relax.yaml
+++ b/.chloggen/go-relax.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: 'bug_fix'
+
+# The name of the component, or a single word describing the area of concern, (e.g. crosslink)
+component: all
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Relax minimum Go version to 1.22 in various modules
+
+# One or more tracking issues related to the change
+issues: [666]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/checkfile/go.mod
+++ b/checkfile/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/build-tools/checkfile
 
-go 1.22.0
+go 1.22
 
 require github.com/stretchr/testify v1.10.0
 

--- a/chloggen/go.mod
+++ b/chloggen/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/build-tools/chloggen
 
-go 1.22.0
+go 1.22
 
 require (
 	github.com/spf13/cobra v1.8.1

--- a/githubgen/go.mod
+++ b/githubgen/go.mod
@@ -2,8 +2,6 @@ module go.opentelemetry.io/build-tools/githubgen
 
 go 1.22.0
 
-toolchain go1.23.4
-
 require (
 	github.com/google/go-github/v66 v66.0.0
 	github.com/stretchr/testify v1.10.0

--- a/githubgen/go.mod
+++ b/githubgen/go.mod
@@ -2,6 +2,8 @@ module go.opentelemetry.io/build-tools/githubgen
 
 go 1.22.0
 
+toolchain go1.23.4
+
 require (
 	github.com/google/go-github/v66 v66.0.0
 	github.com/stretchr/testify v1.10.0

--- a/gotmpl/go.mod
+++ b/gotmpl/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/build-tools/gotmpl
 
-go 1.22.0
+go 1.22
 
 require (
 	github.com/spf13/pflag v1.0.5

--- a/internal/tools/go.sum
+++ b/internal/tools/go.sum
@@ -324,6 +324,7 @@ github.com/gostaticanalysis/nilerr v0.1.1 h1:ThE+hJP0fEp4zWLkWHWcRyI2Od0p7DlgYG3
 github.com/gostaticanalysis/nilerr v0.1.1/go.mod h1:wZYb6YI5YAxxq0i1+VJbY0s2YONW0HU0GPE3+5PWN4A=
 github.com/gostaticanalysis/testutil v0.3.1-0.20210208050101-bfb5c8eec0e4/go.mod h1:D+FIZ+7OahH3ePw/izIEeH5I06eKs1IKI4Xr64/Am3M=
 github.com/gostaticanalysis/testutil v0.5.0 h1:Dq4wT1DdTwTGCQQv3rl3IvD5Ld0E6HiY+3Zh0sUGqw8=
+github.com/gostaticanalysis/testutil v0.5.0/go.mod h1:OLQSbuM6zw2EvCcXTz1lVq5unyoNft372msDY0nY5Hs=
 github.com/hashicorp/go-immutable-radix/v2 v2.1.0 h1:CUW5RYIcysz+D3B+l1mDeXrQ7fUvGGCwJfdASSzbrfo=
 github.com/hashicorp/go-immutable-radix/v2 v2.1.0/go.mod h1:hgdqLXA4f6NIjRVisM1TJ9aOJVNRqKZj+xDGF6m7PBw=
 github.com/hashicorp/go-uuid v1.0.3 h1:2gKiV6YVmrJ1i2CKKa9obLvRieoRGviZFL26PcT/Co8=
@@ -595,7 +596,9 @@ github.com/subosito/gotenv v1.6.0 h1:9NlTDc1FTs4qu0DDq7AEtTPNw6SVm7uBMsUCUjABIf8
 github.com/subosito/gotenv v1.6.0/go.mod h1:Dk4QP5c2W3ibzajGcXpNraDfq2IrhjMIvMSWPKKo0FU=
 github.com/tdakkota/asciicheck v0.3.0 h1:LqDGgZdholxZMaJgpM6b0U9CFIjDCbFdUF00bDnBKOQ=
 github.com/tdakkota/asciicheck v0.3.0/go.mod h1:KoJKXuX/Z/lt6XzLo8WMBfQGzak0SrAKZlvRr4tg8Ac=
+github.com/tenntenn/modver v1.0.1 h1:2klLppGhDgzJrScMpkj9Ujy3rXPUspSjAcev9tSEBgA=
 github.com/tenntenn/modver v1.0.1/go.mod h1:bePIyQPb7UeioSRkw3Q0XeMhYZSMx9B8ePqg6SAMGH0=
+github.com/tenntenn/text/transform v0.0.0-20200319021203-7eef512accb3 h1:f+jULpRQGxTSkNYKJ51yaw6ChIqO+Je8UqsTKN/cDag=
 github.com/tenntenn/text/transform v0.0.0-20200319021203-7eef512accb3/go.mod h1:ON8b8w4BN/kE1EOhwT0o+d62W65a6aPw1nouo9LMgyY=
 github.com/tetafro/godot v1.4.20 h1:z/p8Ek55UdNvzt4TFn2zx2KscpW4rWqcnUrdmvWJj7E=
 github.com/tetafro/godot v1.4.20/go.mod h1:2oVxTBSftRTh4+MVfUaUXR6bn2GDXCaMcOG4Dk3rfio=

--- a/issuegenerator/go.mod
+++ b/issuegenerator/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/build-tools/issuegenerator
 
-go 1.22.0
+go 1.22
 
 require (
 	github.com/google/go-github v17.0.0+incompatible


### PR DESCRIPTION
Thanks to https://github.com/grpc-ecosystem/grpc-gateway/pull/5094

CC @codeboten 

We cannot do it for all modules because of https://cs.opensource.google/go/x/mod/+/refs/tags/v0.22.0:go.mod.
I created https://go-review.googlesource.com/c/mod/+/642200