### PR TITLE
Fix CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -13,4 +13,4 @@
 #
 # For anything not explicitly taken by someone else:
 
-* @open-telemetry/go-maintainers @open-telemetry/go-approvers @open-telemetry/collector-maintainers @open-telemetry/collector-approvers @open-telemetry/collector-contrib-maintainer @open-telemetry/collector-contrib-approvers
+* @open-telemetry/go-maintainers @open-telemetry/go-approvers @open-telemetry/collector-maintainers @open-telemetry/collector-approvers @open-telemetry/collector-contrib-maintainers @open-telemetry/collector-contrib-approvers


### PR DESCRIPTION
Fix collector-contrib-maintainers group name.

https://github.com/orgs/open-telemetry/teams/collector-contrib-maintainers