### PR TITLE
Print the correct workflow link in issue body

### DIFF
--- a/.chloggen/fix-issuegenerator-body.yaml
+++ b/.chloggen/fix-issuegenerator-body.yaml
@@ -8,7 +8,7 @@ component: issuegenerator
 note: Print correct workflow link in the issue body.
 
 # One or more tracking issues related to the change
-issues: []
+issues: [840]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/.chloggen/fix-issuegenerator-title.yaml
+++ b/.chloggen/fix-issuegenerator-title.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. crosslink)
+component: issuegenerator
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Print correct workflow link in the issue body.
+
+# One or more tracking issues related to the change
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/issuegenerator/main.go
+++ b/issuegenerator/main.go
@@ -225,7 +225,7 @@ func (rg *reportGenerator) templateHelper(param string) string {
 	case "jobName":
 		return "`" + rg.envVariables[githubWorkflow] + "`"
 	case "linkToBuild":
-		return fmt.Sprintf("%s/%s/actions/runs/%s", rg.envVariables[githubServerURL], rg.envVariables[githubOwnerAndRepository], rg.envVariables[githubRunID])
+		return fmt.Sprintf("%s/%s/%s/actions/runs/%s", rg.envVariables[githubServerURL], rg.envVariables["githubOwner"], rg.envVariables["githubRepository"], rg.envVariables[githubRunID])
 	case "failedTests":
 		return rg.reports[rg.reportIterator].getFailedTests()
 	default:


### PR DESCRIPTION
An oversight while working on https://github.com/open-telemetry/opentelemetry-go-build-tools/pull/720. It turns out I forgot to update one place.

We noticed while rolling out the automation in the contrib repository: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/39585

cc @mx-psi 