### PR TITLE
Trim repository name from Issue title

### DIFF
--- a/.chloggen/fix-issuegenerator-title.yaml
+++ b/.chloggen/fix-issuegenerator-title.yaml
@@ -8,7 +8,7 @@ component: issuegenerator
 note: Trim repository name from the module name in the issue title.
 
 # One or more tracking issues related to the change
-issues: []
+issues: [841]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/.chloggen/fix-issuegenerator-title.yaml
+++ b/.chloggen/fix-issuegenerator-title.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. crosslink)
+component: issuegenerator
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Trim repository name from the module name in the issue title.
+
+# One or more tracking issues related to the change
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/issuegenerator/main.go
+++ b/issuegenerator/main.go
@@ -252,6 +252,7 @@ func (rg *reportGenerator) getExistingIssue(module string) *github.Issue {
 		rg.handleBadResponses(response)
 	}
 
+	module = strings.TrimPrefix(module, fmt.Sprintf("github.com/%s/%s/", rg.envVariables["githubOwner"], rg.envVariables["githubRepository"]))
 	requiredTitle := strings.Replace(issueTitleTemplate, "${module}", module, 1)
 	for _, issue := range issues {
 		if *issue.Title == requiredTitle {


### PR DESCRIPTION
Another problem we noticed while rolling this out. Our "Ping codeowners" automation doesn't work for the full module name, so we're trimming it.

Also caught upstream: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/39585