### PR TITLE
[issuegenerator] Trim module name when creating a new issue

### DIFF
--- a/.chloggen/trim_issue_title.yaml
+++ b/.chloggen/trim_issue_title.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. crosslink)
+component: issuegenerator
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Trim repository prefix from new issue titles
+
+# One or more tracking issues related to the change
+issues: [864]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/issuegenerator/main.go
+++ b/issuegenerator/main.go
@@ -94,11 +94,7 @@ func newReportGenerator() *reportGenerator {
 }
 
 func trimModule(owner, repo, module string) string {
-	httpsPrefix := "https://"
-	if strings.HasPrefix(module, httpsPrefix) {
-		module = strings.TrimPrefix(module, httpsPrefix)
-	}
-
+	module = strings.TrimPrefix(module, "https://")
 	return strings.TrimPrefix(module, fmt.Sprintf("github.com/%s/%s/", owner, repo))
 }
 

--- a/issuegenerator/main.go
+++ b/issuegenerator/main.go
@@ -94,7 +94,6 @@ func newReportGenerator() *reportGenerator {
 }
 
 func trimModule(owner, repo, module string) string {
-	module = strings.TrimPrefix(module, "https://")
 	return strings.TrimPrefix(module, fmt.Sprintf("github.com/%s/%s/", owner, repo))
 }
 

--- a/issuegenerator/main.go
+++ b/issuegenerator/main.go
@@ -294,7 +294,8 @@ func (rg *reportGenerator) commentOnIssue(issue *github.Issue) *github.IssueComm
 
 // createIssue creates a new GitHub Issue corresponding to a build failure.
 func (rg *reportGenerator) createIssue(r report) *github.Issue {
-	title := strings.Replace(issueTitleTemplate, "${module}", r.module, 1)
+	trimmedModule := strings.TrimPrefix(r.module, fmt.Sprintf("github.com/%s/%s/", rg.envVariables["githubOwner"], rg.envVariables["githubRepository"]))
+	title := strings.Replace(issueTitleTemplate, "${module}", trimmedModule, 1)
 	body := os.Expand(issueBodyTemplate, rg.templateHelper)
 
 	issue, response, err := rg.client.Issues.Create(

--- a/issuegenerator/main.go
+++ b/issuegenerator/main.go
@@ -94,9 +94,9 @@ func newReportGenerator() *reportGenerator {
 }
 
 func trimModule(owner, repo, module string) string {
-	https_prefix := "https://"
-	if strings.HasPrefix(module, https_prefix) {
-		module = strings.TrimPrefix(module, https_prefix)
+	httpsPrefix := "https://"
+	if strings.HasPrefix(module, httpsPrefix) {
+		module = strings.TrimPrefix(module, httpsPrefix)
 	}
 
 	return strings.TrimPrefix(module, fmt.Sprintf("github.com/%s/%s/", owner, repo))

--- a/issuegenerator/main_test.go
+++ b/issuegenerator/main_test.go
@@ -108,3 +108,42 @@ func TestIngestArtifacts(t *testing.T) {
 	require.Equal(t, expectedTestResults, rg.testSuites)
 
 }
+
+func TestTrimPath(t *testing.T) {
+
+	tests := []struct {
+		name           string
+		owner          string
+		repo           string
+		module         string
+		expectedModule string
+	}{
+		{
+			name:           "Test contrib host metrics integration path with https prefix",
+			owner:          "open-telemetry",
+			repo:           "opentelemetry-collector-contrib",
+			module:         "https://github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver/integration_test.go",
+			expectedModule: "receiver/hostmetricsreceiver/integration_test.go",
+		},
+		{
+			name:           "Test contrib host metrics integration path",
+			owner:          "open-telemetry",
+			repo:           "opentelemetry-collector-contrib",
+			module:         "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver/integration_test.go",
+			expectedModule: "receiver/hostmetricsreceiver/integration_test.go",
+		},
+		{
+			name:           "Test core otlphttp exporter test path",
+			owner:          "open-telemetry",
+			repo:           "opentelemetry-collector",
+			module:         "github.com/open-telemetry/opentelemetry-collector/exporter/otlphttpexporter/otlp_test.go",
+			expectedModule: "exporter/otlphttpexporter/otlp_test.go",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.expectedModule, trimModule(tt.owner, tt.repo, tt.module))
+		})
+	}
+}

--- a/issuegenerator/main_test.go
+++ b/issuegenerator/main_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	"github.com/joshdk/go-junit"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -110,40 +111,32 @@ func TestIngestArtifacts(t *testing.T) {
 }
 
 func TestTrimPath(t *testing.T) {
-
 	tests := []struct {
-		name           string
-		owner          string
-		repo           string
-		module         string
-		expectedModule string
+		name       string
+		owner      string
+		repo       string
+		module     string
+		wantModule string
 	}{
 		{
-			name:           "Test contrib host metrics integration path with https prefix",
-			owner:          "open-telemetry",
-			repo:           "opentelemetry-collector-contrib",
-			module:         "https://github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver/integration_test.go",
-			expectedModule: "receiver/hostmetricsreceiver/integration_test.go",
+			name:       "Test contrib host metrics integration path",
+			owner:      "open-telemetry",
+			repo:       "opentelemetry-collector-contrib",
+			module:     "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver/integration_test.go",
+			wantModule: "receiver/hostmetricsreceiver/integration_test.go",
 		},
 		{
-			name:           "Test contrib host metrics integration path",
-			owner:          "open-telemetry",
-			repo:           "opentelemetry-collector-contrib",
-			module:         "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver/integration_test.go",
-			expectedModule: "receiver/hostmetricsreceiver/integration_test.go",
-		},
-		{
-			name:           "Test core otlphttp exporter test path",
-			owner:          "open-telemetry",
-			repo:           "opentelemetry-collector",
-			module:         "github.com/open-telemetry/opentelemetry-collector/exporter/otlphttpexporter/otlp_test.go",
-			expectedModule: "exporter/otlphttpexporter/otlp_test.go",
+			name:       "Test core otlphttp exporter test path",
+			owner:      "open-telemetry",
+			repo:       "opentelemetry-collector",
+			module:     "github.com/open-telemetry/opentelemetry-collector/exporter/otlphttpexporter/otlp_test.go",
+			wantModule: "exporter/otlphttpexporter/otlp_test.go",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			require.Equal(t, tt.expectedModule, trimModule(tt.owner, tt.repo, tt.module))
+			assert.Equal(t, tt.wantModule, trimModule(tt.owner, tt.repo, tt.module), "owner: %s, repo: %s, module: %s, wantModule: %s", tt.owner, tt.repo, tt.module, tt.wantModule)
 		})
 	}
 }


### PR DESCRIPTION
When checking to see if an existing issue is already open for a failed test module, the module name is trimmed to remove the github repo prefix of `github.com/githubOwner/githubRepository/`. However, when creating an issue, the entire module name is being used. Names need to be consistent to ensure duplicates are not filed, and frequency is added to existing issues when necessary. This fixes them to be consistent.

Resolves https://github.com/open-telemetry/opentelemetry-go-build-tools/issues/861