### PR TITLE
issuegenerator: Include test failure messages in Issue comments

### DIFF
--- a/.chloggen/include-test-failure-message.yaml
+++ b/.chloggen/include-test-failure-message.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. crosslink)
+component: issuegenerator
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Include test failure message in the issue comment.
+
+# One or more tracking issues related to the change
+issues: [1065]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/issuegenerator/main.go
+++ b/issuegenerator/main.go
@@ -75,7 +75,7 @@ type reportGenerator struct {
 
 type report struct {
 	module      string
-	failedTests []string
+	failedTests map[string]string
 }
 
 func newReportGenerator() *reportGenerator {
@@ -181,11 +181,11 @@ func (rg *reportGenerator) processTestResults() {
 
 		r := report{
 			module:      module,
-			failedTests: make([]string, 0, suite.Totals.Failed),
+			failedTests: make(map[string]string, suite.Totals.Failed),
 		}
 		for _, t := range suite.Tests {
 			if t.Status == junit.StatusFailed {
-				r.failedTests = append(r.failedTests, t.Name)
+				r.failedTests[t.Name] = t.Error.Error()
 			}
 		}
 		rg.reports = append(rg.reports, r)
@@ -335,8 +335,8 @@ func (r *report) getFailedTests() string {
 	var sb strings.Builder
 	sb.WriteString("#### Test Failures\n")
 
-	for _, s := range r.failedTests {
-		sb.WriteString("-  `" + s + "`\n")
+	for testName, testError := range r.failedTests {
+		sb.WriteString("-  `" + testName + "`\n```\n" + testError + "\n```\n")
 	}
 
 	return sb.String()


### PR DESCRIPTION
After some feedback[[1](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/40331#issuecomment-2914022459)][[2](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/41354#issuecomment-3104680165)], I'm also adding the test failure messages in the comments so people don't need to hunt them down 