### PR TITLE
[chloggen] Accept entries with `.yml` extension

### DIFF
--- a/.chloggen/chloggen-yml-support.yaml
+++ b/.chloggen/chloggen-yml-support.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. crosslink)
+component: chloggen
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Add support for YAML files that use the alternate `.yml` extension"
+
+# One or more tracking issues related to the change
+issues: [1079]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/chloggen/internal/chlog/entry.go
+++ b/chloggen/internal/chlog/entry.go
@@ -103,7 +103,7 @@ func (e Entry) Validate(requireChangelog bool, components []string, validChangeL
 
 // ReadEntries reads changelog entries from YAML files based on the provided configuration.
 func ReadEntries(cfg *config.Config) (map[string][]*Entry, error) {
-	yamlFiles, err := filepath.Glob(filepath.Join(cfg.EntriesDir, "*.yaml"))
+	yamlFiles, err := findYamlFiles(cfg.EntriesDir)
 	if err != nil {
 		return nil, err
 	}
@@ -144,7 +144,7 @@ func ReadEntries(cfg *config.Config) (map[string][]*Entry, error) {
 
 // DeleteEntries deletes changelog entries from YAML files based on the provided configuration.
 func DeleteEntries(cfg *config.Config) error {
-	yamlFiles, err := filepath.Glob(filepath.Join(cfg.EntriesDir, "*.yaml"))
+	yamlFiles, err := findYamlFiles(cfg.EntriesDir)
 	if err != nil {
 		return err
 	}
@@ -159,4 +159,20 @@ func DeleteEntries(cfg *config.Config) error {
 		}
 	}
 	return nil
+}
+
+// findYamlFiles finds all YAML files in the specified directory.
+// It includes files with both .yaml and .yml extensions.
+func findYamlFiles(dir string) ([]string, error) {
+	yamlFiles, err := filepath.Glob(filepath.Join(dir, "*.yaml"))
+	if err != nil {
+		return nil, fmt.Errorf("failed to find YAML files in %s: %w", dir, err)
+	}
+
+	ymlFiles, err := filepath.Glob(filepath.Join(dir, "*.yml"))
+	if err != nil {
+		return nil, fmt.Errorf("failed to find YML files in %s: %w", dir, err)
+	}
+
+	return slices.Concat(yamlFiles, ymlFiles), nil
 }

--- a/chloggen/internal/chlog/entry_test.go
+++ b/chloggen/internal/chlog/entry_test.go
@@ -338,7 +338,7 @@ func TestReadDeleteEntries(t *testing.T) {
 	assert.FileExists(t, cfg.TemplateYAML)
 }
 
-func TestFindYamlFiles_EmptyDir(t *testing.T) {
+func TestFindYamlFilesEmptyDir(t *testing.T) {
 	dir := t.TempDir()
 
 	files, err := findYamlFiles(dir)
@@ -346,7 +346,7 @@ func TestFindYamlFiles_EmptyDir(t *testing.T) {
 	assert.Empty(t, files)
 }
 
-func TestFindYamlFiles_BothExtensions(t *testing.T) {
+func TestFindYamlFilesBothExtensions(t *testing.T) {
 	dir := t.TempDir()
 
 	yamlFile, err := os.Create(filepath.Join(dir, "one.yaml")) //nolint:gosec
@@ -367,7 +367,7 @@ func TestFindYamlFiles_BothExtensions(t *testing.T) {
 	assert.ElementsMatch(t, []string{yamlFile.Name(), ymlFile.Name()}, files)
 }
 
-func TestFindYamlFiles_NonRecursive(t *testing.T) {
+func TestFindYamlFilesNonRecursive(t *testing.T) {
 	dir := t.TempDir()
 
 	// Create a YAML file in the root dir


### PR DESCRIPTION
Fixes #1079.

Adds support for reading and deleting entries that end up with `.yml` so that YAML files with this alternative extension are properly processed into the changelog.