### PR TITLE
[issuegenerator] add pr number in comment template

### DIFF
--- a/.chloggen/add-pr-number-comment.yaml
+++ b/.chloggen/add-pr-number-comment.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. crosslink)
+component: issuegenerator
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add PR number to issue comments
+
+# One or more tracking issues related to the change
+issues: [1180]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/issuegenerator/internal/github/client.go
+++ b/issuegenerator/internal/github/client.go
@@ -67,6 +67,7 @@ this issue is open, will be added as comments with more information to this issu
 	issueCommentTemplate = `
 Link to latest failed build: ${linkToBuild}
 Commit: ${commit}
+PR: ${prNumber}
 
 ${failedTests}
 `

--- a/issuegenerator/internal/github/client_test.go
+++ b/issuegenerator/internal/github/client_test.go
@@ -142,6 +142,7 @@ this issue is open, will be added as comments with more information to this issu
 			expected: `
 Link to latest failed build: https://github.com/test-org/test-repo/actions/runs/555555
 Commit: abcde12
+PR: N/A
 
 #### Test Failures
 -  ` + "`TestFailure`" + `


### PR DESCRIPTION
related #1180 

adds pr number in the failing test comments generated by issuegenerator