### PR TITLE
CI: AFFECTED_MODULES should exclude internal/tools and checkapi internals.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -191,4 +191,14 @@ jobs:
           echo "AFFECTED_FILES=$AFFECTED_FILES"
           chmod +x ./get_affected_pkgs.sh
           AFFECTED_MODULES=$(./get_affected_pkgs.sh $AFFECTED_FILES)
+
+          # Exclude tools and checkapi internal modules
+          TOOLS_MOD_DIR="./internal/tools"
+          CHECKAPI_INTERNAL_MOD_DIRS=$(find ./checkapi/internal -type f -name 'go.mod' -exec dirname {} \;)
+          
+          for exclude in $TOOLS_MOD_DIR $CHECKAPI_INTERNAL_MOD_DIRS; do
+            AFFECTED_MODULES=$(echo "$AFFECTED_MODULES" | tr ' ' '\n' | grep -v "^${exclude#./}" | tr '\n' ' ')
+          done
+
+          AFFECTED_MODULES=$(echo "$AFFECTED_MODULES" | xargs)
           echo "affected_modules=$AFFECTED_MODULES" >> $GITHUB_OUTPUT

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -192,11 +192,11 @@ jobs:
           chmod +x ./get_affected_pkgs.sh
           AFFECTED_MODULES=$(./get_affected_pkgs.sh $AFFECTED_FILES)
 
-          # Exclude tools and checkapi internal modules
+          # Exclude tools and internal test modules
           TOOLS_MOD_DIR="./internal/tools"
-          CHECKAPI_INTERNAL_MOD_DIRS=$(find ./checkapi/internal -type f -name 'go.mod' -exec dirname {} \;)
-          
-          for exclude in $TOOLS_MOD_DIR $CHECKAPI_INTERNAL_MOD_DIRS; do
+          INTERNAL_TEST_MOD_DIRS=$(find ./*/internal/test* -type f -name 'go.mod' -exec dirname {} \;)
+
+          for exclude in $TOOLS_MOD_DIR $INTERNAL_TEST_MOD_DIRS; do
             AFFECTED_MODULES=$(echo "$AFFECTED_MODULES" | tr ' ' '\n' | grep -v "^${exclude#./}" | tr '\n' ' ')
           done
 

--- a/Makefile
+++ b/Makefile
@@ -28,12 +28,12 @@ else
 endif
 
 TOOLS_MOD_DIR := ./internal/tools
-CHECKAPI_INTERNAL_MOD_DIRS := $(shell find ./checkapi/internal -type f -name 'go.mod' -exec dirname {} \; | sort)
+INTERNAL_TEST_MOD_DIRS := $(shell find ./*/internal/test* -type f -name 'go.mod' -exec dirname {} \; | sort)
 
 # All source code and documents. Used in spell check.
 ALL_DOCS := $(shell find . -name '*.md' -type f | sort)
 # All directories with go.mod files related to opentelemetry library. Used for building, testing and linting.
-ALL_GO_MOD_DIRS := $(filter-out $(TOOLS_MOD_DIR) $(CHECKAPI_INTERNAL_MOD_DIRS), $(shell find . -type f -name 'go.mod' -exec dirname {} \; | sort))
+ALL_GO_MOD_DIRS := $(filter-out $(TOOLS_MOD_DIR) $(INTERNAL_TEST_MOD_DIRS), $(shell find . -type f -name 'go.mod' -exec dirname {} \; | sort))
 ALL_COVERAGE_MOD_DIRS := $(shell find . -type f -name 'go.mod' -exec dirname {} \; | grep -v '^$(TOOLS_MOD_DIR)' | sort)
 
 GO ?= go


### PR DESCRIPTION
We override variable ALL_GO_MOD_DIRS in Makefile, however in the construction of it there we exclude TOOLS_MOD_DIR and CHECKAPI_INTERNAL_MOD_DIRS, refer https://github.com/open-telemetry/opentelemetry-go-build-tools/blob/main/Makefile#L36,
however the script that currently generated affected packages for ci does not remove them which leads to unwanted dirs in AFFECTED_MODULES.

Skip the modules in TOOLS_MOD_DIR and CHECKAPI_INTERNAL_MOD_DIRS in CI when we pass AFFECTED_MODULES from detected-changes. Ad generalise CHECKAPI_INTERNAL_MOD_DIRS to INTERNAL_TEST_MOD_DIRS