### PR TITLE
chore: prepare release 0.30.0

### DIFF
--- a/crosslink/go.mod
+++ b/crosslink/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.10
 	github.com/stretchr/testify v1.11.1
-	go.opentelemetry.io/build-tools v0.29.0
+	go.opentelemetry.io/build-tools v0.30.0
 	go.uber.org/zap v1.27.1
 	golang.org/x/mod v0.35.0
 )

--- a/dbotconf/go.mod
+++ b/dbotconf/go.mod
@@ -5,7 +5,7 @@ go 1.25.0
 require (
 	github.com/spf13/cobra v1.10.2
 	github.com/stretchr/testify v1.11.1
-	go.opentelemetry.io/build-tools v0.29.0
+	go.opentelemetry.io/build-tools v0.30.0
 	golang.org/x/mod v0.35.0
 	gopkg.in/yaml.v3 v3.0.1
 )

--- a/internal/tools/go.mod
+++ b/internal/tools/go.mod
@@ -7,10 +7,10 @@ require (
 	github.com/gogo/protobuf v1.3.2
 	github.com/golangci/golangci-lint/v2 v2.11.4
 	github.com/matryer/moq v0.6.0
-	go.opentelemetry.io/build-tools/chloggen v0.29.0
-	go.opentelemetry.io/build-tools/crosslink v0.29.0
-	go.opentelemetry.io/build-tools/dbotconf v0.29.0
-	go.opentelemetry.io/build-tools/multimod v0.29.0
+	go.opentelemetry.io/build-tools/chloggen v0.30.0
+	go.opentelemetry.io/build-tools/crosslink v0.30.0
+	go.opentelemetry.io/build-tools/dbotconf v0.30.0
+	go.opentelemetry.io/build-tools/multimod v0.30.0
 	golang.org/x/vuln v1.2.0
 )
 
@@ -221,7 +221,7 @@ require (
 	go-simpler.org/sloglint v0.11.1 // indirect
 	go.augendre.info/arangolint v0.4.0 // indirect
 	go.augendre.info/fatcontext v0.9.0 // indirect
-	go.opentelemetry.io/build-tools v0.29.0 // indirect
+	go.opentelemetry.io/build-tools v0.30.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap v1.27.1 // indirect
 	go.yaml.in/yaml/v2 v2.4.4 // indirect

--- a/multimod/go.mod
+++ b/multimod/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/viper v1.21.0
 	github.com/stretchr/testify v1.11.1
-	go.opentelemetry.io/build-tools v0.29.0
+	go.opentelemetry.io/build-tools v0.30.0
 	go.uber.org/multierr v1.11.0
 	golang.org/x/mod v0.35.0
 	golang.org/x/sync v0.20.0

--- a/versions.yaml
+++ b/versions.yaml
@@ -14,7 +14,7 @@
 
 module-sets:
   tools:
-    version: v0.29.0
+    version: v0.30.0
     modules:
       - go.opentelemetry.io/build-tools
       - go.opentelemetry.io/build-tools/checkapi


### PR DESCRIPTION
A bunch of dependencies have been updated since the last release, probably a good time to release a new minor version.