### PR TITLE
grater: Add methods for executing basic repetitive commands.

### DIFF
--- a/grater/internal/commands/commands.go
+++ b/grater/internal/commands/commands.go
@@ -12,7 +12,7 @@ import (
 )
 
 // GetModule downloads a module via the Go module proxy to the given path.
-func GetModule(ctx context.Context, c container.Container, useContainerResp container.UseContainerResponse, module module.Module, modulePath string) error {
+func GetModuleFromProxy(ctx context.Context, c container.Container, useContainerResp container.UseContainerResponse, module module.Module, modulePath string) error {
 	script := fmt.Sprintf(
 		`set -e
 	GOMODCACHE=$(mktemp -d)

--- a/grater/internal/commands/commands.go
+++ b/grater/internal/commands/commands.go
@@ -18,7 +18,7 @@ func ShallowClone(ctx context.Context, c container.Container, useContainerResp c
 	if branch != "" {
 		args = append(args, "--branch", branch)
 	}
-	args = append(args, "https://" + module.ModulePath + ".git", modulePath)
+	args = append(args, "https://"+module.ModulePath+".git", modulePath)
 
 	_, err := c.ExecuteCommand(ctx,
 		container.NewExecuteCommandConfig(
@@ -49,8 +49,8 @@ func CheckoutBranch(ctx context.Context, c container.Container, useContainerResp
 }
 
 // SetReplaceDirective adds a new replace directive in the go.mod file on the given path.
-func SetReplaceDirective(ctx context.Context, c container.Container, useContainerResp container.UseContainerResponse, old, new, modulePath string) error {
-	replace := fmt.Sprintf("%s=%s", old, new)
+func SetReplaceDirective(ctx context.Context, c container.Container, useContainerResp container.UseContainerResponse, oldRef, newRef, modulePath string) error {
+	replace := fmt.Sprintf("%s=%s", oldRef, newRef)
 
 	_, err := c.ExecuteCommand(ctx,
 		container.NewExecuteCommandConfig(
@@ -80,7 +80,7 @@ func SetReplaceDirective(ctx context.Context, c container.Container, useContaine
 }
 
 // RunModuleTest runs the test of a single module and returns an execute command response.
-func RunModuleTest(ctx context.Context, c container.Container, useContainerResp container.UseContainerResponse, modulePath string) (container.ExecuteCommandResponse, error){
+func RunModuleTest(ctx context.Context, c container.Container, useContainerResp container.UseContainerResponse, modulePath string) (container.ExecuteCommandResponse, error) {
 	resp, err := c.ExecuteCommand(ctx,
 		container.NewExecuteCommandConfig(
 			container.WithContainerID(useContainerResp.ContainerID),

--- a/grater/internal/commands/commands.go
+++ b/grater/internal/commands/commands.go
@@ -58,43 +58,43 @@ func CheckoutBranch(ctx context.Context, c container.Container, useContainerResp
 
 // SetReplaceDirective adds a new replace directive in the go.mod file on the given path.
 func SetReplaceDirective(ctx context.Context, c container.Container, useContainerResp container.UseContainerResponse, oldModule, newModule module.Module, modulePath string) error {
-    oldRef := oldModule.ModulePath
-    if oldModule.ModuleVersion != "" {
-        oldRef = fmt.Sprintf("%s@%s", oldModule.ModulePath, oldModule.ModuleVersion)
-    }
+	oldRef := oldModule.ModulePath
+	if oldModule.ModuleVersion != "" {
+		oldRef = fmt.Sprintf("%s@%s", oldModule.ModulePath, oldModule.ModuleVersion)
+	}
 
-    newRef := newModule.ModulePath
-    if newModule.ModuleVersion != "" {
-        newRef = fmt.Sprintf("%s@%s", newModule.ModulePath, newModule.ModuleVersion)
-    }
+	newRef := newModule.ModulePath
+	if newModule.ModuleVersion != "" {
+		newRef = fmt.Sprintf("%s@%s", newModule.ModulePath, newModule.ModuleVersion)
+	}
 
-    replace := fmt.Sprintf("%s=%s", oldRef, newRef)
+	replace := fmt.Sprintf("%s=%s", oldRef, newRef)
 
-    _, err := c.ExecuteCommand(ctx,
-        container.NewExecuteCommandConfig(
-            container.WithContainerID(useContainerResp.ContainerID),
-            container.WithCommand([]string{
-                "sh", "-c", fmt.Sprintf(`cd %s && go mod edit -replace %s`, modulePath, replace),
-            }),
-        ),
-    )
-    if err != nil {
-        return err
-    }
+	_, err := c.ExecuteCommand(ctx,
+		container.NewExecuteCommandConfig(
+			container.WithContainerID(useContainerResp.ContainerID),
+			container.WithCommand([]string{
+				"sh", "-c", fmt.Sprintf(`cd %s && go mod edit -replace %s`, modulePath, replace),
+			}),
+		),
+	)
+	if err != nil {
+		return err
+	}
 
-    _, err = c.ExecuteCommand(ctx,
-        container.NewExecuteCommandConfig(
-            container.WithContainerID(useContainerResp.ContainerID),
-            container.WithCommand([]string{
-                "sh", "-c", fmt.Sprintf(`cd %s && go mod tidy`, modulePath),
-            }),
-        ),
-    )
-    if err != nil {
-        return err
-    }
+	_, err = c.ExecuteCommand(ctx,
+		container.NewExecuteCommandConfig(
+			container.WithContainerID(useContainerResp.ContainerID),
+			container.WithCommand([]string{
+				"sh", "-c", fmt.Sprintf(`cd %s && go mod tidy`, modulePath),
+			}),
+		),
+	)
+	if err != nil {
+		return err
+	}
 
-    return nil
+	return nil
 }
 
 // RunModuleTest runs the test of a single module and returns an execute command response.

--- a/grater/internal/commands/commands.go
+++ b/grater/internal/commands/commands.go
@@ -1,5 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
+
 // Package commands provides utilities to execute commands.
 package commands
 
@@ -11,7 +12,7 @@ import (
 	"go.opentelemetry.io/build-tools/grater/internal/module"
 )
 
-// GetModule downloads a module via the Go module proxy to the given path.
+// GetModuleFromProxy downloads a module via the Go module proxy to the given path.
 func GetModuleFromProxy(ctx context.Context, c container.Container, useContainerResp container.UseContainerResponse, module module.Module, modulePath string) error {
 	script := fmt.Sprintf(
 		`set -e

--- a/grater/internal/commands/commands.go
+++ b/grater/internal/commands/commands.go
@@ -1,0 +1,5 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+// Package commands provides utilities to execute commands.
+package commands

--- a/grater/internal/commands/commands.go
+++ b/grater/internal/commands/commands.go
@@ -1,6 +1,5 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
-
 // Package commands provides utilities to execute commands.
 package commands
 
@@ -28,7 +27,7 @@ rm -rf "$GOMODCACHE" "$GOPATH"`,
 		modulePath, modulePath,
 	)
 
-	_, err := c.ExecuteCommand(ctx,
+	resp, err := c.ExecuteCommand(ctx,
 		container.NewExecuteCommandConfig(
 			container.WithContainerID(useContainerResp.ContainerID),
 			container.WithCommand([]string{"sh", "-c", script}),
@@ -42,12 +41,11 @@ rm -rf "$GOMODCACHE" "$GOPATH"`,
 
 // CheckoutBranch checks out the provided branch on the given path.
 func CheckoutBranch(ctx context.Context, c container.Container, useContainerResp container.UseContainerResponse, branch, modulePath string) error {
-	_, err := c.ExecuteCommand(ctx,
+	resp, err := c.ExecuteCommand(ctx,
 		container.NewExecuteCommandConfig(
 			container.WithContainerID(useContainerResp.ContainerID),
-			container.WithCommand([]string{
-				"git", "-C", modulePath, "checkout", branch,
-			}),
+			container.WithWorkingDir(modulePath),
+			container.WithCommand([]string{"git", "checkout", branch}),
 		),
 	)
 	if err != nil {
@@ -70,24 +68,22 @@ func SetReplaceDirective(ctx context.Context, c container.Container, useContaine
 
 	replace := fmt.Sprintf("%s=%s", oldRef, newRef)
 
-	_, err := c.ExecuteCommand(ctx,
+	resp, err := c.ExecuteCommand(ctx,
 		container.NewExecuteCommandConfig(
 			container.WithContainerID(useContainerResp.ContainerID),
-			container.WithCommand([]string{
-				"sh", "-c", fmt.Sprintf(`cd %s && go mod edit -replace %s`, modulePath, replace),
-			}),
+			container.WithWorkingDir(modulePath),
+			container.WithCommand([]string{"go", "mod", "edit", "-replace", replace}),
 		),
 	)
 	if err != nil {
 		return err
 	}
 
-	_, err = c.ExecuteCommand(ctx,
+	resp, err = c.ExecuteCommand(ctx,
 		container.NewExecuteCommandConfig(
 			container.WithContainerID(useContainerResp.ContainerID),
-			container.WithCommand([]string{
-				"sh", "-c", fmt.Sprintf(`cd %s && go mod tidy`, modulePath),
-			}),
+			container.WithWorkingDir(modulePath),
+			container.WithCommand([]string{"go", "mod", "tidy"}),
 		),
 	)
 	if err != nil {
@@ -102,15 +98,12 @@ func RunModuleTest(ctx context.Context, c container.Container, useContainerResp 
 	resp, err := c.ExecuteCommand(ctx,
 		container.NewExecuteCommandConfig(
 			container.WithContainerID(useContainerResp.ContainerID),
-			container.WithCommand([]string{
-				"sh", "-c", "cd " + modulePath + " && go test -v ./...",
-			}),
+			container.WithWorkingDir(modulePath),
+			container.WithCommand([]string{"go", "test", "-v", "./..."}),
 		),
 	)
-
 	if err != nil {
 		return container.ExecuteCommandResponse{}, err
 	}
-
 	return resp, nil
 }

--- a/grater/internal/commands/commands.go
+++ b/grater/internal/commands/commands.go
@@ -39,21 +39,6 @@ rm -rf "$GOMODCACHE" "$GOPATH"`,
 	return nil
 }
 
-// CheckoutBranch checks out the provided branch on the given path.
-func CheckoutBranch(ctx context.Context, c container.Container, useContainerResp container.UseContainerResponse, branch, modulePath string) error {
-	resp, err := c.ExecuteCommand(ctx,
-		container.NewExecuteCommandConfig(
-			container.WithContainerID(useContainerResp.ContainerID),
-			container.WithWorkingDir(modulePath),
-			container.WithCommand([]string{"git", "checkout", branch}),
-		),
-	)
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
 // SetReplaceDirective adds a new replace directive in the go.mod file on the given path.
 func SetReplaceDirective(ctx context.Context, c container.Container, useContainerResp container.UseContainerResponse, oldModule, newModule module.Module, modulePath string) error {
 	oldRef := oldModule.ModulePath

--- a/grater/internal/commands/commands.go
+++ b/grater/internal/commands/commands.go
@@ -15,21 +15,26 @@ import (
 func GetModule(ctx context.Context, c container.Container, useContainerResp container.UseContainerResponse, module module.Module, modulePath string) error {
 	script := fmt.Sprintf(
 		`set -e
-GOMODCACHE=$(mktemp -d)
-GOPATH=$(mktemp -d)
-OUT=$(GOMODCACHE="$GOMODCACHE" GOPATH="$GOPATH" GONOSUMCHECK="*" GONOSUMDB="*" \
-  go mod download -json %s@%s)
-DIR=$(echo "$OUT" | grep '"Dir"' | awk -F'"' '{print $4}')
-mkdir -p %s
-cp -r "$DIR"/. %s/
-rm -rf "$GOMODCACHE" "$GOPATH"`,
-		module.ModulePath, module.ModuleVersion,
-		modulePath, modulePath,
+	GOMODCACHE=$(mktemp -d)
+	GOPATH=$(mktemp -d)
+
+	OUT=$(GOMODCACHE="$GOMODCACHE" GOPATH="$GOPATH" \
+	GONOSUMCHECK="*" GONOSUMDB="*" \
+	go mod download -json %s@%s)
+
+	DIR=$(echo "$OUT" | grep '"Dir"' | awk -F'"' '{print $4}')
+
+	cp -r "$DIR"/. .
+
+	rm -rf "$GOMODCACHE" "$GOPATH"`,
+		module.ModulePath,
+		module.ModuleVersion,
 	)
 
-	resp, err := c.ExecuteCommand(ctx,
+	_, err := c.ExecuteCommand(ctx,
 		container.NewExecuteCommandConfig(
 			container.WithContainerID(useContainerResp.ContainerID),
+			container.WithWorkingDir(modulePath),
 			container.WithCommand([]string{"sh", "-c", script}),
 		),
 	)
@@ -53,7 +58,7 @@ func SetReplaceDirective(ctx context.Context, c container.Container, useContaine
 
 	replace := fmt.Sprintf("%s=%s", oldRef, newRef)
 
-	resp, err := c.ExecuteCommand(ctx,
+	_, err := c.ExecuteCommand(ctx,
 		container.NewExecuteCommandConfig(
 			container.WithContainerID(useContainerResp.ContainerID),
 			container.WithWorkingDir(modulePath),
@@ -64,7 +69,7 @@ func SetReplaceDirective(ctx context.Context, c container.Container, useContaine
 		return err
 	}
 
-	resp, err = c.ExecuteCommand(ctx,
+	_, err = c.ExecuteCommand(ctx,
 		container.NewExecuteCommandConfig(
 			container.WithContainerID(useContainerResp.ContainerID),
 			container.WithWorkingDir(modulePath),

--- a/grater/internal/commands/commands.go
+++ b/grater/internal/commands/commands.go
@@ -3,3 +3,96 @@
 
 // Package commands provides utilities to execute commands.
 package commands
+
+import (
+	"context"
+	"fmt"
+
+	"go.opentelemetry.io/build-tools/grater/internal/container"
+	"go.opentelemetry.io/build-tools/grater/internal/module"
+)
+
+// ShallowClone shallow clones a module inside a container to the given path.
+func ShallowClone(ctx context.Context, c container.Container, useContainerResp container.UseContainerResponse, module module.Module, branch, modulePath string) error {
+	args := []string{"git", "clone", "--depth=1"}
+	if branch != "" {
+		args = append(args, "--branch", branch)
+	}
+	args = append(args, "https://" + module.ModulePath + ".git", modulePath)
+
+	_, err := c.ExecuteCommand(ctx,
+		container.NewExecuteCommandConfig(
+			container.WithContainerID(useContainerResp.ContainerID),
+			container.WithCommand(args),
+		),
+	)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// CheckoutBranch checks out the provided branch on the given path.
+func CheckoutBranch(ctx context.Context, c container.Container, useContainerResp container.UseContainerResponse, branch, modulePath string) error {
+	_, err := c.ExecuteCommand(ctx,
+		container.NewExecuteCommandConfig(
+			container.WithContainerID(useContainerResp.ContainerID),
+			container.WithCommand([]string{
+				"git", "-C", modulePath, "checkout", branch,
+			}),
+		),
+	)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// SetReplaceDirective adds a new replace directive in the go.mod file on the given path.
+func SetReplaceDirective(ctx context.Context, c container.Container, useContainerResp container.UseContainerResponse, old, new, modulePath string) error {
+	replace := fmt.Sprintf("%s=%s", old, new)
+
+	_, err := c.ExecuteCommand(ctx,
+		container.NewExecuteCommandConfig(
+			container.WithContainerID(useContainerResp.ContainerID),
+			container.WithCommand([]string{
+				"sh", "-c", fmt.Sprintf(`cd %s && go mod edit -replace %s`, modulePath, replace),
+			}),
+		),
+	)
+	if err != nil {
+		return err
+	}
+
+	_, err = c.ExecuteCommand(ctx,
+		container.NewExecuteCommandConfig(
+			container.WithContainerID(useContainerResp.ContainerID),
+			container.WithCommand([]string{
+				"sh", "-c", fmt.Sprintf(`cd %s && go mod tidy`, modulePath),
+			}),
+		),
+	)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// RunModuleTest runs the test of a single module and returns an execute command response.
+func RunModuleTest(ctx context.Context, c container.Container, useContainerResp container.UseContainerResponse, modulePath string) (container.ExecuteCommandResponse, error){
+	resp, err := c.ExecuteCommand(ctx,
+		container.NewExecuteCommandConfig(
+			container.WithContainerID(useContainerResp.ContainerID),
+			container.WithCommand([]string{
+				"sh", "-c", "cd " + modulePath + " && go test -v ./...",
+			}),
+		),
+	)
+
+	if err != nil {
+		return container.ExecuteCommandResponse{}, err
+	}
+
+	return resp, nil
+}

--- a/grater/internal/commands/commands.go
+++ b/grater/internal/commands/commands.go
@@ -12,18 +12,26 @@ import (
 	"go.opentelemetry.io/build-tools/grater/internal/module"
 )
 
-// ShallowClone shallow clones a module inside a container to the given path.
-func ShallowClone(ctx context.Context, c container.Container, useContainerResp container.UseContainerResponse, module module.Module, branch, modulePath string) error {
-	args := []string{"git", "clone", "--depth=1"}
-	if branch != "" {
-		args = append(args, "--branch", branch)
-	}
-	args = append(args, "https://"+module.ModulePath+".git", modulePath)
+// GetModule downloads a module via the Go module proxy to the given path.
+func GetModule(ctx context.Context, c container.Container, useContainerResp container.UseContainerResponse, module module.Module, modulePath string) error {
+	script := fmt.Sprintf(
+		`set -e
+GOMODCACHE=$(mktemp -d)
+GOPATH=$(mktemp -d)
+OUT=$(GOMODCACHE="$GOMODCACHE" GOPATH="$GOPATH" GONOSUMCHECK="*" GONOSUMDB="*" \
+  go mod download -json %s@%s)
+DIR=$(echo "$OUT" | grep '"Dir"' | awk -F'"' '{print $4}')
+mkdir -p %s
+cp -r "$DIR"/. %s/
+rm -rf "$GOMODCACHE" "$GOPATH"`,
+		module.ModulePath, module.ModuleVersion,
+		modulePath, modulePath,
+	)
 
 	_, err := c.ExecuteCommand(ctx,
 		container.NewExecuteCommandConfig(
 			container.WithContainerID(useContainerResp.ContainerID),
-			container.WithCommand(args),
+			container.WithCommand([]string{"sh", "-c", script}),
 		),
 	)
 	if err != nil {
@@ -49,34 +57,44 @@ func CheckoutBranch(ctx context.Context, c container.Container, useContainerResp
 }
 
 // SetReplaceDirective adds a new replace directive in the go.mod file on the given path.
-func SetReplaceDirective(ctx context.Context, c container.Container, useContainerResp container.UseContainerResponse, oldRef, newRef, modulePath string) error {
-	replace := fmt.Sprintf("%s=%s", oldRef, newRef)
+func SetReplaceDirective(ctx context.Context, c container.Container, useContainerResp container.UseContainerResponse, oldModule, newModule module.Module, modulePath string) error {
+    oldRef := oldModule.ModulePath
+    if oldModule.ModuleVersion != "" {
+        oldRef = fmt.Sprintf("%s@%s", oldModule.ModulePath, oldModule.ModuleVersion)
+    }
 
-	_, err := c.ExecuteCommand(ctx,
-		container.NewExecuteCommandConfig(
-			container.WithContainerID(useContainerResp.ContainerID),
-			container.WithCommand([]string{
-				"sh", "-c", fmt.Sprintf(`cd %s && go mod edit -replace %s`, modulePath, replace),
-			}),
-		),
-	)
-	if err != nil {
-		return err
-	}
+    newRef := newModule.ModulePath
+    if newModule.ModuleVersion != "" {
+        newRef = fmt.Sprintf("%s@%s", newModule.ModulePath, newModule.ModuleVersion)
+    }
 
-	_, err = c.ExecuteCommand(ctx,
-		container.NewExecuteCommandConfig(
-			container.WithContainerID(useContainerResp.ContainerID),
-			container.WithCommand([]string{
-				"sh", "-c", fmt.Sprintf(`cd %s && go mod tidy`, modulePath),
-			}),
-		),
-	)
-	if err != nil {
-		return err
-	}
+    replace := fmt.Sprintf("%s=%s", oldRef, newRef)
 
-	return nil
+    _, err := c.ExecuteCommand(ctx,
+        container.NewExecuteCommandConfig(
+            container.WithContainerID(useContainerResp.ContainerID),
+            container.WithCommand([]string{
+                "sh", "-c", fmt.Sprintf(`cd %s && go mod edit -replace %s`, modulePath, replace),
+            }),
+        ),
+    )
+    if err != nil {
+        return err
+    }
+
+    _, err = c.ExecuteCommand(ctx,
+        container.NewExecuteCommandConfig(
+            container.WithContainerID(useContainerResp.ContainerID),
+            container.WithCommand([]string{
+                "sh", "-c", fmt.Sprintf(`cd %s && go mod tidy`, modulePath),
+            }),
+        ),
+    )
+    if err != nil {
+        return err
+    }
+
+    return nil
 }
 
 // RunModuleTest runs the test of a single module and returns an execute command response.

--- a/grater/internal/commands/commands_test.go
+++ b/grater/internal/commands/commands_test.go
@@ -81,7 +81,7 @@ func TestSetReplaceDirective(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	err = SetReplaceDirective(ctx, c, useContainerResp, "module", "../moduleFail", "/dependent/")
+	err = SetReplaceDirective(ctx, c, useContainerResp, "go.opentelemetry.io/build-tools/grater/module", "../moduleFail", "/dependent/")
 	require.NoError(t, err)
 
 	resp, err := c.ExecuteCommand(ctx,
@@ -91,7 +91,7 @@ func TestSetReplaceDirective(t *testing.T) {
 		),
 	)
 
-	assert.Contains(t, resp.Output, `replace module => ../moduleFail`)
+	assert.Contains(t, resp.Output, `replace go.opentelemetry.io/build-tools/grater/module => ../moduleFail`)
 }
 
 func TestRunModuleTest(t *testing.T) {
@@ -104,7 +104,7 @@ func TestRunModuleTest(t *testing.T) {
 
 	binds := map[string]string{
 		"../testdata/dependent":"/dependent/",
-		"../testdata/modulePass":"/modulePass",
+		"../testdata/modulePass":"/modulePass/",
 	}
 	useContainerResp, err := c.UseContainer(ctx,
 		container.NewUseContainerConfig(
@@ -115,7 +115,6 @@ func TestRunModuleTest(t *testing.T) {
 	require.NoError(t, err)
 
 	resp, err := RunModuleTest(ctx, c, useContainerResp, "/dependent/")
-	t.Log(resp.Output)
 	require.NoError(t, err)
 	assert.Equal(t, 0, resp.ExitCode)
 }

--- a/grater/internal/commands/commands_test.go
+++ b/grater/internal/commands/commands_test.go
@@ -18,7 +18,7 @@ import (
 	"go.opentelemetry.io/build-tools/grater/internal/module"
 )
 
-func TestGetModule(t *testing.T) {
+func TestGetModuleFromProxy(t *testing.T) {
 	ctx := context.Background()
 	var c container.Container
 	c, err := dockercontainer.NewDockerContainer()
@@ -43,7 +43,7 @@ func TestGetModule(t *testing.T) {
 
 	mod := module.NewModule("go.opentelemetry.io/otel", "v1.24.0")
 
-	err = GetModule(ctx, c, useContainerResp, *mod, "/module/")
+	err = GetModuleFromProxy(ctx, c, useContainerResp, *mod, "/module/")
 	require.NoError(t, err)
 
 	resp, err := c.ExecuteCommand(ctx,

--- a/grater/internal/commands/commands_test.go
+++ b/grater/internal/commands/commands_test.go
@@ -19,31 +19,41 @@ import (
 )
 
 func TestGetModule(t *testing.T) {
-    ctx := context.Background()
-    var c container.Container
-    c, err := dockercontainer.NewDockerContainer()
-    require.NoError(t, err)
+	ctx := context.Background()
+	var c container.Container
+	c, err := dockercontainer.NewDockerContainer()
+	require.NoError(t, err)
 
-    useContainerResp, err := c.UseContainer(ctx,
-        container.NewUseContainerConfig(
-            container.WithImageName("golang:1.25"),
-        ),
-    )
-    require.NoError(t, err)
+	useContainerResp, err := c.UseContainer(ctx,
+		container.NewUseContainerConfig(
+			container.WithImageName("golang:1.25"),
+		),
+	)
+	require.NoError(t, err)
 
-    mod := module.NewModule("go.opentelemetry.io/otel", "v1.24.0")
+	_, err = c.ExecuteCommand(ctx,
+		container.NewExecuteCommandConfig(
+			container.WithContainerID(useContainerResp.ContainerID),
+			container.WithCommand([]string{
+				"mkdir", "-p", "/module/",
+			}),
+		),
+	)
+	require.NoError(t, err)
 
-    err = GetModule(ctx, c, useContainerResp, *mod, "/module/")
-    require.NoError(t, err)
+	mod := module.NewModule("go.opentelemetry.io/otel", "v1.24.0")
 
-    resp, err := c.ExecuteCommand(ctx,
-        container.NewExecuteCommandConfig(
-            container.WithContainerID(useContainerResp.ContainerID),
-            container.WithCommand([]string{"cat", "/module/go.mod"}),
-        ),
-    )
-    require.NoError(t, err)
-    assert.Contains(t, resp.Output, "go.opentelemetry.io/otel")
+	err = GetModule(ctx, c, useContainerResp, *mod, "/module/")
+	require.NoError(t, err)
+
+	resp, err := c.ExecuteCommand(ctx,
+		container.NewExecuteCommandConfig(
+			container.WithContainerID(useContainerResp.ContainerID),
+			container.WithCommand([]string{"cat", "/module/go.mod"}),
+		),
+	)
+	require.NoError(t, err)
+	assert.Contains(t, resp.Output, "go.opentelemetry.io/otel")
 }
 
 func TestSetReplaceDirective(t *testing.T) {

--- a/grater/internal/commands/commands_test.go
+++ b/grater/internal/commands/commands_test.go
@@ -1,0 +1,4 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package commands

--- a/grater/internal/commands/commands_test.go
+++ b/grater/internal/commands/commands_test.go
@@ -81,7 +81,7 @@ func TestSetReplaceDirective(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	err = SetReplaceDirective(ctx, c, useContainerResp, "go.opentelemetry.io/build-tools/grater/module", "../moduleFail", "/dependent/")
+	err = SetReplaceDirective(ctx, c, useContainerResp, "go.opentelemetry.io/build-tools/grater/internal/testdata/module", "../moduleFail", "/dependent/")
 	require.NoError(t, err)
 
 	resp, err := c.ExecuteCommand(ctx,
@@ -91,7 +91,7 @@ func TestSetReplaceDirective(t *testing.T) {
 		),
 	)
 
-	assert.Contains(t, resp.Output, `replace go.opentelemetry.io/build-tools/grater/module => ../moduleFail`)
+	assert.Contains(t, resp.Output, `replace go.opentelemetry.io/build-tools/grater/internal/testdata/module => ../moduleFail`)
 }
 
 func TestRunModuleTest(t *testing.T) {

--- a/grater/internal/commands/commands_test.go
+++ b/grater/internal/commands/commands_test.go
@@ -18,44 +18,32 @@ import (
 	"go.opentelemetry.io/build-tools/grater/internal/module"
 )
 
-func TestShallowClone(t *testing.T) {
-	ctx := context.Background()
+func TestGetModule(t *testing.T) {
+    ctx := context.Background()
+    var c container.Container
+    c, err := dockercontainer.NewDockerContainer()
+    require.NoError(t, err)
 
-	var c container.Container
+    useContainerResp, err := c.UseContainer(ctx,
+        container.NewUseContainerConfig(
+            container.WithImageName("golang:1.22"),
+        ),
+    )
+    require.NoError(t, err)
 
-	c, err := dockercontainer.NewDockerContainer()
-	require.NoError(t, err)
+    mod := module.NewModule("go.opentelemetry.io/otel", "v1.24.0")
 
-	useContainerResp, err := c.UseContainer(ctx,
-		container.NewUseContainerConfig(
-			container.WithImageName("golang:1.22"),
-		),
-	)
+    err = GetModule(ctx, c, useContainerResp, *mod, "/module/")
+    require.NoError(t, err)
 
-	module := *module.NewModule("github.com/open-telemetry/opentelemetry-go-build-tools", "")
-	modulePath := "/mainModule/" + module.ModuleName
-	branch := "main"
-
-	err = ShallowClone(ctx, c, useContainerResp, module, branch, modulePath)
-	require.NoError(t, err)
-
-	resp, err := c.ExecuteCommand(ctx,
-		container.NewExecuteCommandConfig(
-			container.WithContainerID(useContainerResp.ContainerID),
-			container.WithCommand([]string{"ls", "/mainModule/"}),
-		),
-	)
-	require.NoError(t, err)
-	assert.Equal(t, "opentelemetry-go-build-tools", resp.Output)
-
-	resp, err = c.ExecuteCommand(ctx,
-    container.NewExecuteCommandConfig(
-        container.WithContainerID(useContainerResp.ContainerID),
-        container.WithCommand([]string{"git", "-C", modulePath, "rev-parse", "--is-shallow-repository"}),
-		),
-	)
-	require.NoError(t, err)
-	assert.Equal(t, "true", resp.Output)
+    resp, err := c.ExecuteCommand(ctx,
+        container.NewExecuteCommandConfig(
+            container.WithContainerID(useContainerResp.ContainerID),
+            container.WithCommand([]string{"cat", "/module/go.mod"}),
+        ),
+    )
+    require.NoError(t, err)
+    assert.Contains(t, resp.Output, "go.opentelemetry.io/otel")
 }
 
 func TestCheckoutBranch(t *testing.T) {
@@ -81,7 +69,10 @@ func TestSetReplaceDirective(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	err = SetReplaceDirective(ctx, c, useContainerResp, "go.opentelemetry.io/build-tools/grater/internal/testdata/module", "../moduleFail", "/dependent/")
+	oldModule := *module.NewModule("go.opentelemetry.io/build-tools/grater/internal/testdata/module", "")
+	newModule := *module.NewModule("../moduleFail", "")
+
+	err = SetReplaceDirective(ctx, c, useContainerResp, oldModule, newModule, "/dependent/")
 	require.NoError(t, err)
 
 	resp, err := c.ExecuteCommand(ctx,

--- a/grater/internal/commands/commands_test.go
+++ b/grater/internal/commands/commands_test.go
@@ -26,7 +26,7 @@ func TestGetModule(t *testing.T) {
 
     useContainerResp, err := c.UseContainer(ctx,
         container.NewUseContainerConfig(
-            container.WithImageName("golang:1.22"),
+            container.WithImageName("golang:1.25"),
         ),
     )
     require.NoError(t, err)
@@ -59,11 +59,12 @@ func TestSetReplaceDirective(t *testing.T) {
 	require.NoError(t, err)
 
 	binds := map[string]string{
-		"../testdata/dependent":"/dependent/",
+		"../testdata/dependent": "/dependent/",
+		"../testdata/moduleFail": "/moduleFail/",
 	}
 	useContainerResp, err := c.UseContainer(ctx,
 		container.NewUseContainerConfig(
-			container.WithImageName("golang:1.22"),
+			container.WithImageName("golang:1.25.0"),
 			container.WithHostToContainerPaths(binds),
 		),
 	)

--- a/grater/internal/commands/commands_test.go
+++ b/grater/internal/commands/commands_test.go
@@ -1,4 +1,121 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
+//go:build integration
+// +build integration
+
 package commands
+
+import (
+	"testing"
+	"context"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.opentelemetry.io/build-tools/grater/internal/container"
+	"go.opentelemetry.io/build-tools/grater/internal/dockercontainer"
+	"go.opentelemetry.io/build-tools/grater/internal/module"
+)
+
+func TestShallowClone(t *testing.T) {
+	ctx := context.Background()
+
+	var c container.Container
+
+	c, err := dockercontainer.NewDockerContainer()
+	require.NoError(t, err)
+
+	useContainerResp, err := c.UseContainer(ctx,
+		container.NewUseContainerConfig(
+			container.WithImageName("golang:1.22"),
+		),
+	)
+
+	module := *module.NewModule("github.com/open-telemetry/opentelemetry-go-build-tools", "")
+	modulePath := "/mainModule/" + module.ModuleName
+	branch := "main"
+
+	err = ShallowClone(ctx, c, useContainerResp, module, branch, modulePath)
+	require.NoError(t, err)
+
+	resp, err := c.ExecuteCommand(ctx,
+		container.NewExecuteCommandConfig(
+			container.WithContainerID(useContainerResp.ContainerID),
+			container.WithCommand([]string{"ls", "/mainModule/"}),
+		),
+	)
+	require.NoError(t, err)
+	assert.Equal(t, "opentelemetry-go-build-tools", resp.Output)
+
+	resp, err = c.ExecuteCommand(ctx,
+    container.NewExecuteCommandConfig(
+        container.WithContainerID(useContainerResp.ContainerID),
+        container.WithCommand([]string{"git", "-C", modulePath, "rev-parse", "--is-shallow-repository"}),
+		),
+	)
+	require.NoError(t, err)
+	assert.Equal(t, "true", resp.Output)
+}
+
+func TestCheckoutBranch(t *testing.T) {
+	// TODO: Add remote testing functionality for checkout branch.
+}
+
+func TestSetReplaceDirective(t *testing.T) {
+	ctx := context.Background()
+
+	var c container.Container
+
+	c, err := dockercontainer.NewDockerContainer()
+	require.NoError(t, err)
+
+	binds := map[string]string{
+		"../testdata/dependent":"/dependent/",
+	}
+	useContainerResp, err := c.UseContainer(ctx,
+		container.NewUseContainerConfig(
+			container.WithImageName("golang:1.22"),
+			container.WithHostToContainerPaths(binds),
+		),
+	)
+	require.NoError(t, err)
+
+	err = SetReplaceDirective(ctx, c, useContainerResp, "module", "../moduleFail", "/dependent/")
+	require.NoError(t, err)
+
+	resp, err := c.ExecuteCommand(ctx,
+	container.NewExecuteCommandConfig(
+			container.WithContainerID(useContainerResp.ContainerID),
+			container.WithCommand([]string{"cat", "/dependent/go.mod"}),
+		),
+	)
+
+	assert.Contains(t, resp.Output, `replace module => ../moduleFail`)
+}
+
+func TestRunModuleTest(t *testing.T) {
+	ctx := context.Background()
+
+	var c container.Container
+
+	c, err := dockercontainer.NewDockerContainer()
+	require.NoError(t, err)
+
+	binds := map[string]string{
+		"../testdata/dependent":"/dependent/",
+		"../testdata/modulePass":"/modulePass",
+	}
+	useContainerResp, err := c.UseContainer(ctx,
+		container.NewUseContainerConfig(
+			container.WithImageName("golang:1.25.0"),
+			container.WithHostToContainerPaths(binds),
+		),
+	)
+	require.NoError(t, err)
+
+	resp, err := RunModuleTest(ctx, c, useContainerResp, "/dependent/")
+	t.Log(resp.Output)
+	require.NoError(t, err)
+	assert.Equal(t, 0, resp.ExitCode)
+}

--- a/grater/internal/commands/commands_test.go
+++ b/grater/internal/commands/commands_test.go
@@ -46,10 +46,6 @@ func TestGetModule(t *testing.T) {
     assert.Contains(t, resp.Output, "go.opentelemetry.io/otel")
 }
 
-func TestCheckoutBranch(t *testing.T) {
-	// TODO: Add remote testing functionality for checkout branch.
-}
-
 func TestSetReplaceDirective(t *testing.T) {
 	ctx := context.Background()
 

--- a/grater/internal/container/config.go
+++ b/grater/internal/container/config.go
@@ -7,6 +7,7 @@ package container
 type ExecuteCommandConfig struct {
 	containerID string
 	cmd         []string
+	workingDir  string
 }
 
 // ContainerID returns the container ID.
@@ -17,6 +18,11 @@ func (cfg *ExecuteCommandConfig) ContainerID() string {
 // Cmd returns the command to execute.
 func (cfg *ExecuteCommandConfig) Cmd() []string {
 	return cfg.cmd
+}
+
+// WorkingDir returns the workingDir.
+func (cfg *ExecuteCommandConfig) WorkingDir() string {
+	return cfg.workingDir
 }
 
 // NewExecuteCommandConfig applies all the options to a returned ExecuteCommandConfig.
@@ -123,6 +129,14 @@ func WithContainerID(id string) ExecuteCommandOption {
 func WithCommand(cmd []string) ExecuteCommandOption {
 	return executeCommandOptionFunc(func(cfg ExecuteCommandConfig) ExecuteCommandConfig {
 		cfg.cmd = cmd
+		return cfg
+	})
+}
+
+// WithWorkingDir sets the workingDir.
+func WithWorkingDir(workingDir string) ExecuteCommandOption {
+	return executeCommandOptionFunc(func(cfg ExecuteCommandConfig) ExecuteCommandConfig {
+		cfg.workingDir = workingDir
 		return cfg
 	})
 }

--- a/grater/internal/container/config_test.go
+++ b/grater/internal/container/config_test.go
@@ -62,6 +62,35 @@ func TestNewExecuteCommandConfig(t *testing.T) {
 				cmd:         []string{"echo", "hello"},
 			},
 		},
+		{
+			[]ExecuteCommandOption{
+				WithWorkingDir("/some/path"),
+			},
+			ExecuteCommandConfig{
+				workingDir: "/some/path",
+			},
+		},
+		{
+			[]ExecuteCommandOption{
+				WithWorkingDir("/some/path"),
+				WithWorkingDir("/other/path"),
+			},
+			ExecuteCommandConfig{
+				workingDir: "/other/path",
+			},
+		},
+		{
+			[]ExecuteCommandOption{
+				WithContainerID("test-container"),
+				WithCommand([]string{"go", "mod", "tidy"}),
+				WithWorkingDir("/some/path"),
+			},
+			ExecuteCommandConfig{
+				containerID: "test-container",
+				cmd:         []string{"go", "mod", "tidy"},
+				workingDir:  "/some/path",
+			},
+		},
 	}
 	for _, test := range tests {
 		assert.Equal(t, test.expected, NewExecuteCommandConfig(test.options...))

--- a/grater/internal/dockercontainer/dockercontainer.go
+++ b/grater/internal/dockercontainer/dockercontainer.go
@@ -117,6 +117,7 @@ func (dc *DockerContainer) ExecuteCommand(ctx context.Context, cfg container.Exe
 		AttachStdout: true,
 		AttachStderr: true,
 		TTY:          true,
+		WorkingDir:   cfg.WorkingDir(),
 	})
 	if err != nil {
 		return container.ExecuteCommandResponse{}, err

--- a/grater/internal/dockercontainer/dockercontainer_integration_test.go
+++ b/grater/internal/dockercontainer/dockercontainer_integration_test.go
@@ -307,6 +307,38 @@ func TestExecuteCommandInvalidContainerFails(t *testing.T) {
 	assert.Equal(t, 0, cmdResp.ExitCode)
 }
 
+func TestExecuteCommandSetsWorkingDir(t *testing.T) {
+	dc, err := NewDockerContainer()
+	require.NoError(t, err)
+
+	resp, err := dc.UseContainer(context.Background(), container.NewUseContainerConfig(
+		container.WithImageName("ubuntu:latest"),
+	))
+	require.NoError(t, err)
+	defer resp.Cleanup()
+
+	cmdResp, err := dc.ExecuteCommand(context.Background(), container.NewExecuteCommandConfig(
+		container.WithContainerID(resp.ContainerID),
+		container.WithCommand([]string{"mkdir", "-p", "/module/"}),
+	))
+	require.NoError(t, err)
+
+	cmdResp, err = dc.ExecuteCommand(context.Background(), container.NewExecuteCommandConfig(
+		container.WithContainerID(resp.ContainerID),
+		container.WithCommand([]string{"mkdir", "test-module"}),
+		container.WithWorkingDir("/module/"),
+	))
+	require.NoError(t, err)
+
+	cmdResp, err = dc.ExecuteCommand(context.Background(), container.NewExecuteCommandConfig(
+		container.WithContainerID(resp.ContainerID),
+		container.WithCommand([]string{"ls", "test-module"}),
+		container.WithWorkingDir("/module/"),
+	))
+	require.NoError(t, err)
+	assert.Equal(t, 0, cmdResp.ExitCode)
+}
+
 func TestPullImage(t *testing.T) {
 	dc, err := NewDockerContainer()
 	require.NoError(t, err)

--- a/grater/internal/testdata/dependent/go.mod
+++ b/grater/internal/testdata/dependent/go.mod
@@ -1,0 +1,14 @@
+module dependent
+
+go 1.25.1
+
+require module v0.0.0
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/stretchr/testify v1.11.1 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)
+
+replace module => ../modulePass

--- a/grater/internal/testdata/dependent/go.mod
+++ b/grater/internal/testdata/dependent/go.mod
@@ -1,8 +1,8 @@
-module dependent
+module go.opentelemetry.io/build-tools/grater/dependent
 
 go 1.25.0
 
-require module v0.0.0
+require go.opentelemetry.io/build-tools/grater/module v0.0.0
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
@@ -11,4 +11,4 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
-replace module => ../modulePass
+replace go.opentelemetry.io/build-tools/grater/module => ../modulePass

--- a/grater/internal/testdata/dependent/go.mod
+++ b/grater/internal/testdata/dependent/go.mod
@@ -1,8 +1,8 @@
-module go.opentelemetry.io/build-tools/grater/dependent
+module go.opentelemetry.io/build-tools/grater/internal/testdata/dependent
 
 go 1.25.0
 
-require go.opentelemetry.io/build-tools/grater/module v0.0.0
+require go.opentelemetry.io/build-tools/grater/internal/testdata/module v0.0.0
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
@@ -11,4 +11,4 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
-replace go.opentelemetry.io/build-tools/grater/module => ../modulePass
+replace go.opentelemetry.io/build-tools/grater/internal/testdata/module => ../modulePass

--- a/grater/internal/testdata/dependent/go.mod
+++ b/grater/internal/testdata/dependent/go.mod
@@ -1,6 +1,6 @@
 module dependent
 
-go 1.25.1
+go 1.25.0
 
 require module v0.0.0
 

--- a/grater/internal/testdata/dependent/go.sum
+++ b/grater/internal/testdata/dependent/go.sum
@@ -1,0 +1,9 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
+github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/grater/internal/testdata/dependent/main.go
+++ b/grater/internal/testdata/dependent/main.go
@@ -1,0 +1,14 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+// Package dependent represents a dependent module.
+package dependent
+
+import (
+	"module"
+)
+
+// Add method uses Add from the module imported.
+func Add(a, b int) int {
+	return module.Add(a, b)
+}

--- a/grater/internal/testdata/dependent/main.go
+++ b/grater/internal/testdata/dependent/main.go
@@ -5,7 +5,7 @@
 package dependent
 
 import (
-	"go.opentelemetry.io/build-tools/grater/module"
+	"go.opentelemetry.io/build-tools/grater/internal/testdata/module"
 )
 
 // Add method uses Add from the module imported.

--- a/grater/internal/testdata/dependent/main.go
+++ b/grater/internal/testdata/dependent/main.go
@@ -5,7 +5,7 @@
 package dependent
 
 import (
-	"module"
+	"go.opentelemetry.io/build-tools/grater/module"
 )
 
 // Add method uses Add from the module imported.

--- a/grater/internal/testdata/dependent/main_test.go
+++ b/grater/internal/testdata/dependent/main_test.go
@@ -1,0 +1,15 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package dependent
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAdd(t *testing.T) {
+	out := Add(2, 3)
+	assert.Equal(t, out, 5)
+}

--- a/grater/internal/testdata/moduleFail/go.mod
+++ b/grater/internal/testdata/moduleFail/go.mod
@@ -1,0 +1,10 @@
+module module
+
+go 1.25.1
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/stretchr/testify v1.11.1 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)

--- a/grater/internal/testdata/moduleFail/go.mod
+++ b/grater/internal/testdata/moduleFail/go.mod
@@ -1,6 +1,6 @@
 module module
 
-go 1.25.1
+go 1.25.0
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect

--- a/grater/internal/testdata/moduleFail/go.mod
+++ b/grater/internal/testdata/moduleFail/go.mod
@@ -1,4 +1,4 @@
-module module
+module go.opentelemetry.io/build-tools/grater/module
 
 go 1.25.0
 

--- a/grater/internal/testdata/moduleFail/go.mod
+++ b/grater/internal/testdata/moduleFail/go.mod
@@ -1,4 +1,4 @@
-module go.opentelemetry.io/build-tools/grater/module
+module go.opentelemetry.io/build-tools/grater/internal/testdata/module
 
 go 1.25.0
 

--- a/grater/internal/testdata/moduleFail/go.sum
+++ b/grater/internal/testdata/moduleFail/go.sum
@@ -1,0 +1,9 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
+github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/grater/internal/testdata/moduleFail/main.go
+++ b/grater/internal/testdata/moduleFail/main.go
@@ -1,0 +1,10 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+// Package module represents a package with failing implementations for dependents.
+package module
+
+// Add method provides an incorrect implementation of add for moduleFail.
+func Add(a, b int) int {
+	return a * b
+}

--- a/grater/internal/testdata/moduleFail/main_test.go
+++ b/grater/internal/testdata/moduleFail/main_test.go
@@ -1,0 +1,15 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package module
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAdd(t *testing.T) {
+	out := Add(2, 3)
+	assert.Equal(t, out, 6)
+}

--- a/grater/internal/testdata/modulePass/go.mod
+++ b/grater/internal/testdata/modulePass/go.mod
@@ -1,0 +1,10 @@
+module module
+
+go 1.25.1
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/stretchr/testify v1.11.1 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)

--- a/grater/internal/testdata/modulePass/go.mod
+++ b/grater/internal/testdata/modulePass/go.mod
@@ -1,6 +1,6 @@
 module module
 
-go 1.25.1
+go 1.25.0
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect

--- a/grater/internal/testdata/modulePass/go.mod
+++ b/grater/internal/testdata/modulePass/go.mod
@@ -1,4 +1,4 @@
-module module
+module go.opentelemetry.io/build-tools/grater/module
 
 go 1.25.0
 

--- a/grater/internal/testdata/modulePass/go.mod
+++ b/grater/internal/testdata/modulePass/go.mod
@@ -1,4 +1,4 @@
-module go.opentelemetry.io/build-tools/grater/module
+module go.opentelemetry.io/build-tools/grater/internal/testdata/module
 
 go 1.25.0
 

--- a/grater/internal/testdata/modulePass/go.sum
+++ b/grater/internal/testdata/modulePass/go.sum
@@ -1,0 +1,9 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
+github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/grater/internal/testdata/modulePass/main.go
+++ b/grater/internal/testdata/modulePass/main.go
@@ -1,0 +1,10 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+// Package module represents a package with passing implementations for dependents.
+package module
+
+// Add method provides an incorrect implementation of add for modulePass.
+func Add(a, b int) int {
+	return a + b
+}

--- a/grater/internal/testdata/modulePass/main_test.go
+++ b/grater/internal/testdata/modulePass/main_test.go
@@ -1,0 +1,15 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package module
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAdd(t *testing.T) {
+	out := Add(2, 3)
+	assert.Equal(t, out, 5)
+}

--- a/versions.yaml
+++ b/versions.yaml
@@ -30,8 +30,7 @@ module-sets:
 excluded-modules:
   - go.opentelemetry.io/build-tools/grater
   - go.opentelemetry.io/build-tools/grater/internal/testdata/dependent
-  - go.opentelemetry.io/build-tools/grater/internal/testdata/moduleFail
-  - go.opentelemetry.io/build-tools/grater/internal/testdata/modulePass
+  - go.opentelemetry.io/build-tools/grater/internal/testdata/module
   - go.opentelemetry.io/build-tools/internal/tools
   - github.com/open-telemetry/opentelemetry-go-build-tools/checkapi/internal/altpkg/receiver/altreceiver
   - github.com/open-telemetry/opentelemetry-go-build-tools/checkapi/internal/altpkg/receiver/badreceiver

--- a/versions.yaml
+++ b/versions.yaml
@@ -29,9 +29,9 @@ module-sets:
 
 excluded-modules:
   - go.opentelemetry.io/build-tools/grater
-  - go.opentelemetry.io/build-tools/garter/internal/testdata/dependent
-  - go.opentelemetry.io/build-tools/garter/internal/testdata/moduleFail
-  - go.opentelemetry.io/build-tools/garter/internal/testdata/modulePass
+  - go.opentelemetry.io/build-tools/grater/internal/testdata/dependent
+  - go.opentelemetry.io/build-tools/grater/internal/testdata/moduleFail
+  - go.opentelemetry.io/build-tools/grater/internal/testdata/modulePass
   - go.opentelemetry.io/build-tools/internal/tools
   - github.com/open-telemetry/opentelemetry-go-build-tools/checkapi/internal/altpkg/receiver/altreceiver
   - github.com/open-telemetry/opentelemetry-go-build-tools/checkapi/internal/altpkg/receiver/badreceiver

--- a/versions.yaml
+++ b/versions.yaml
@@ -29,6 +29,9 @@ module-sets:
 
 excluded-modules:
   - go.opentelemetry.io/build-tools/grater
+  - go.opentelemetry.io/build-tools/garter/internal/testdata/dependent
+  - go.opentelemetry.io/build-tools/garter/internal/testdata/moduleFail
+  - go.opentelemetry.io/build-tools/garter/internal/testdata/modulePass
   - go.opentelemetry.io/build-tools/internal/tools
   - github.com/open-telemetry/opentelemetry-go-build-tools/checkapi/internal/altpkg/receiver/altreceiver
   - github.com/open-telemetry/opentelemetry-go-build-tools/checkapi/internal/altpkg/receiver/badreceiver


### PR DESCRIPTION
Part of #1528.
- Runner uses a lot of repetitive commands which can be consolidated in a commands/ package to keep them separate and clean from the logic of runner itself.
- Separate commands so we can test their logic independently of runner.
- Add testdata/ with dependent module and modulePass and moduleFail which can be used in commands and runner to invoke different types of testing scenarios.