### PR TITLE
CI: fix coverage report by only reporting coverage for changed modules.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,6 +139,7 @@ jobs:
           make test-integration ALL_GO_MOD_DIRS="$AFFECTED_MODULES"
 
   test-coverage:
+    needs: [detect-changes]
     runs-on: ubuntu-latest
     steps:
     - name: Install Go
@@ -165,7 +166,8 @@ jobs:
 
     - name: Run coverage tests
       run: |
-        make test-coverage
+        AFFECTED_MODULES="${{ needs.detect-changes.outputs.affected_modules }}"
+        make test-coverage ALL_COVERAGE_MOD_DIRS="$AFFECTED_MODULES"
         mkdir $TEST_RESULTS
         cp coverage.out $TEST_RESULTS
         cp coverage.txt $TEST_RESULTS


### PR DESCRIPTION
Part of #1528.

- Integration tests might be flaky as they rely on network calls, separate them from coverage report if changes are not made in those modules.