### PR TITLE
grater: remove the hardcoding of replace paths.

### DIFF
--- a/grater/internal/commands/commands.go
+++ b/grater/internal/commands/commands.go
@@ -46,17 +46,7 @@ func GetModuleFromProxy(ctx context.Context, c container.Container, useContainer
 }
 
 // SetReplaceDirective adds a new replace directive in the go.mod file on the given path.
-func SetReplaceDirective(ctx context.Context, c container.Container, useContainerResp container.UseContainerResponse, oldModule, newModule module.Module, modulePath string) error {
-	oldRef := oldModule.ModulePath
-	if oldModule.ModuleVersion != "" {
-		oldRef = fmt.Sprintf("%s@%s", oldModule.ModulePath, oldModule.ModuleVersion)
-	}
-
-	newRef := newModule.ModulePath
-	if newModule.ModuleVersion != "" {
-		newRef = fmt.Sprintf("%s@%s", newModule.ModulePath, newModule.ModuleVersion)
-	}
-
+func SetReplaceDirective(ctx context.Context, c container.Container, useContainerResp container.UseContainerResponse, oldRef, newRef, modulePath string) error {
 	replace := fmt.Sprintf("%s=%s", oldRef, newRef)
 
 	_, err := c.ExecuteCommand(ctx,

--- a/grater/internal/commands/commands_test.go
+++ b/grater/internal/commands/commands_test.go
@@ -69,7 +69,6 @@ func TestSetReplaceDirective(t *testing.T) {
 		"../testdata/dependent": "/dependent/",
 		"../testdata/moduleFail": "/moduleFail/",
 	}
-
 	useContainerResp, err := c.UseContainer(ctx,
 		container.NewUseContainerConfig(
 			container.WithImageName("golang:1.25.0"),
@@ -94,8 +93,7 @@ func TestSetReplaceDirective(t *testing.T) {
 	err = SetReplaceDirective(ctx, c, useContainerResp, oldRef, newRef, "/dependent/")
 	require.NoError(t, err)
 
-	resp, err := c.ExecuteCommand(
-		ctx,
+	resp, err := c.ExecuteCommand(ctx,
 		container.NewExecuteCommandConfig(
 			container.WithContainerID(useContainerResp.ContainerID),
 			container.WithCommand([]string{"cat", "/dependent/go.mod"}),

--- a/grater/internal/commands/commands_test.go
+++ b/grater/internal/commands/commands_test.go
@@ -59,17 +59,18 @@ func TestGetModuleFromProxy(t *testing.T) {
 
 func TestSetReplaceDirective(t *testing.T) {
 	ctx := context.Background()
+
 	var c container.Container
+
 	c, err := dockercontainer.NewDockerContainer()
 	require.NoError(t, err)
 
 	binds := map[string]string{
-		"../testdata/dependent":  "/dependent/",
+		"../testdata/dependent": "/dependent/",
 		"../testdata/moduleFail": "/moduleFail/",
 	}
 
-	useContainerResp, err := c.UseContainer(
-		ctx,
+	useContainerResp, err := c.UseContainer(ctx,
 		container.NewUseContainerConfig(
 			container.WithImageName("golang:1.25.0"),
 			container.WithHostToContainerPaths(binds),
@@ -100,7 +101,6 @@ func TestSetReplaceDirective(t *testing.T) {
 			container.WithCommand([]string{"cat", "/dependent/go.mod"}),
 		),
 	)
-	require.NoError(t, err)
 
 	assert.Contains(t, resp.Output, "replace go.opentelemetry.io/build-tools/grater/internal/testdata/module => ../moduleFail")
 }

--- a/grater/internal/commands/commands_test.go
+++ b/grater/internal/commands/commands_test.go
@@ -59,7 +59,7 @@ func TestGetModuleFromProxy(t *testing.T) {
 
 func TestSetReplaceDirective(t *testing.T) {
 	ctx := context.Background()
-
+	var c container.Container
 	c, err := dockercontainer.NewDockerContainer()
 	require.NoError(t, err)
 
@@ -78,7 +78,6 @@ func TestSetReplaceDirective(t *testing.T) {
 	require.NoError(t, err)
 
 	oldModule := module.NewModule("go.opentelemetry.io/build-tools/grater/internal/testdata/module", "",)
-
 	newModule := module.NewModule("../moduleFail", "")
 
 	oldRef := oldModule.ModulePath

--- a/grater/internal/commands/commands_test.go
+++ b/grater/internal/commands/commands_test.go
@@ -77,8 +77,8 @@ func TestSetReplaceDirective(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	oldModule := module.NewModule("go.opentelemetry.io/build-tools/grater/internal/testdata/module", "",)
-	newModule := module.NewModule("../moduleFail", "")
+	oldModule := *module.NewModule("go.opentelemetry.io/build-tools/grater/internal/testdata/module", "")
+	newModule := *module.NewModule("../moduleFail", "")
 
 	oldRef := oldModule.ModulePath
 	if oldModule.ModuleVersion != "" {
@@ -94,13 +94,13 @@ func TestSetReplaceDirective(t *testing.T) {
 	require.NoError(t, err)
 
 	resp, err := c.ExecuteCommand(ctx,
-		container.NewExecuteCommandConfig(
+	container.NewExecuteCommandConfig(
 			container.WithContainerID(useContainerResp.ContainerID),
 			container.WithCommand([]string{"cat", "/dependent/go.mod"}),
 		),
 	)
 
-	assert.Contains(t, resp.Output, "replace go.opentelemetry.io/build-tools/grater/internal/testdata/module => ../moduleFail")
+	assert.Contains(t, resp.Output, `replace go.opentelemetry.io/build-tools/grater/internal/testdata/module => ../moduleFail`)
 }
 
 func TestRunModuleTest(t *testing.T) {

--- a/grater/internal/commands/commands_test.go
+++ b/grater/internal/commands/commands_test.go
@@ -9,6 +9,7 @@ package commands
 import (
 	"testing"
 	"context"
+	"fmt"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -59,16 +60,16 @@ func TestGetModuleFromProxy(t *testing.T) {
 func TestSetReplaceDirective(t *testing.T) {
 	ctx := context.Background()
 
-	var c container.Container
-
 	c, err := dockercontainer.NewDockerContainer()
 	require.NoError(t, err)
 
 	binds := map[string]string{
-		"../testdata/dependent": "/dependent/",
+		"../testdata/dependent":  "/dependent/",
 		"../testdata/moduleFail": "/moduleFail/",
 	}
-	useContainerResp, err := c.UseContainer(ctx,
+
+	useContainerResp, err := c.UseContainer(
+		ctx,
 		container.NewUseContainerConfig(
 			container.WithImageName("golang:1.25.0"),
 			container.WithHostToContainerPaths(binds),
@@ -76,20 +77,33 @@ func TestSetReplaceDirective(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	oldModule := *module.NewModule("go.opentelemetry.io/build-tools/grater/internal/testdata/module", "")
-	newModule := *module.NewModule("../moduleFail", "")
+	oldModule := module.NewModule("go.opentelemetry.io/build-tools/grater/internal/testdata/module", "",)
 
-	err = SetReplaceDirective(ctx, c, useContainerResp, oldModule, newModule, "/dependent/")
+	newModule := module.NewModule("../moduleFail", "")
+
+	oldRef := oldModule.ModulePath
+	if oldModule.ModuleVersion != "" {
+		oldRef = fmt.Sprintf("%s@%s", oldModule.ModulePath, oldModule.ModuleVersion)
+	}
+
+	newRef := newModule.ModulePath
+	if newModule.ModuleVersion != "" {
+		newRef = fmt.Sprintf("%s@%s", newModule.ModulePath, newModule.ModuleVersion)
+	}
+
+	err = SetReplaceDirective(ctx, c, useContainerResp, oldRef, newRef, "/dependent/")
 	require.NoError(t, err)
 
-	resp, err := c.ExecuteCommand(ctx,
-	container.NewExecuteCommandConfig(
+	resp, err := c.ExecuteCommand(
+		ctx,
+		container.NewExecuteCommandConfig(
 			container.WithContainerID(useContainerResp.ContainerID),
 			container.WithCommand([]string{"cat", "/dependent/go.mod"}),
 		),
 	)
+	require.NoError(t, err)
 
-	assert.Contains(t, resp.Output, `replace go.opentelemetry.io/build-tools/grater/internal/testdata/module => ../moduleFail`)
+	assert.Contains(t, resp.Output, "replace go.opentelemetry.io/build-tools/grater/internal/testdata/module => ../moduleFail")
 }
 
 func TestRunModuleTest(t *testing.T) {


### PR DESCRIPTION
Part of #1528.
- oldRef and newRef being hardcoded makes is difficult to pass multiple different kinds of paths which current implementation does not cover.
- oldRef and newRef were being hardcoded by the SetReplaceDirective due to avoid malicious inputs via. &&, however shell scripts is not used anymore by this method so we can safely remove this hardcoding.