### PR TITLE
[multimod] make tag command idempotent for already-tagged commits

### DIFF
--- a/.chloggen/feat_run-mutimodtag-mutipletimes.yaml
+++ b/.chloggen/feat_run-mutimodtag-mutipletimes.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. crosslink)
+component: multimod
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Running tag on an already-tagged commit now succeeds instead of failing
+
+# One or more tracking issues related to the change
+issues: [205]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/multimod/internal/tag/tag.go
+++ b/multimod/internal/tag/tag.go
@@ -51,8 +51,12 @@ func Run(versioningFile, moduleSetName, commitHash string, deleteModuleSetTags b
 
 		log.Println("Successfully deleted module tags")
 	} else {
-		if err := t.tagAllModules(nil); err != nil {
-			log.Fatalf("unable to tag modules: %v", err)
+		if t.alreadyTagged {
+			log.Println("Tags already exist on specified commit, skipping tag creation")
+		} else {
+			if err := t.tagAllModules(nil); err != nil {
+				log.Fatalf("unable to tag modules: %v", err)
+			}
 		}
 	}
 
@@ -65,8 +69,9 @@ func Run(versioningFile, moduleSetName, commitHash string, deleteModuleSetTags b
 
 type tagger struct {
 	shared.ModuleSetRelease
-	CommitHash plumbing.Hash
-	Repo       *git.Repository
+	CommitHash    plumbing.Hash
+	Repo          *git.Repository
+	alreadyTagged bool
 }
 
 func newTagger(versioningFilename, modSetToUpdate, repoRoot, hash string, deleteModuleSetTags bool) (tagger, error) {
@@ -86,6 +91,7 @@ func newTagger(versioningFilename, modSetToUpdate, repoRoot, hash string, delete
 	}
 
 	modFullTagNames := modRelease.ModuleFullTagNames()
+	var alreadyTagged bool
 
 	if deleteModuleSetTags {
 		if err = verifyTagsOnCommit(modFullTagNames, repo, fullCommitHash); err != nil {
@@ -93,7 +99,14 @@ func newTagger(versioningFilename, modSetToUpdate, repoRoot, hash string, delete
 		}
 	} else {
 		if err = modRelease.CheckGitTagsAlreadyExist(repo); err != nil {
-			return tagger{}, fmt.Errorf("CheckGitTagsAlreadyExist failed: %w", err)
+			var alreadyExistErr shared.ErrGitTagsAlreadyExist
+			if !errors.As(err, &alreadyExistErr) {
+				return tagger{}, fmt.Errorf("CheckGitTagsAlreadyExist failed: %w", err)
+			}
+			if verifyErr := verifyTagsOnCommit(modFullTagNames, repo, fullCommitHash); verifyErr != nil {
+				return tagger{}, fmt.Errorf("tags already exist but not on specified commit: %w", verifyErr)
+			}
+			alreadyTagged = true
 		}
 	}
 
@@ -101,6 +114,7 @@ func newTagger(versioningFilename, modSetToUpdate, repoRoot, hash string, delete
 		ModuleSetRelease: modRelease,
 		CommitHash:       fullCommitHash,
 		Repo:             repo,
+		alreadyTagged:    alreadyTagged,
 	}, nil
 }
 

--- a/multimod/internal/tag/tag_test.go
+++ b/multimod/internal/tag/tag_test.go
@@ -484,6 +484,7 @@ func TestTagAllModules(t *testing.T) {
 		shouldExistTags    []string
 		shouldNotExistTags []string
 		shouldError        bool
+		alreadyTagged      bool
 	}{
 		{
 			name:       "mod_set_1",
@@ -536,7 +537,8 @@ func TestTagAllModules(t *testing.T) {
 				"test/v0.1.0",
 				"v1.0.0-doesNotExist",
 			},
-			shouldError: true,
+			shouldError:   false,
+			alreadyTagged: true,
 		},
 	}
 
@@ -572,6 +574,11 @@ func TestTagAllModules(t *testing.T) {
 				return
 			}
 			require.NoError(t, err)
+			assert.Equal(t, tc.alreadyTagged, tagger.alreadyTagged)
+
+			if tagger.alreadyTagged {
+				return
+			}
 			require.NoError(t, tagger.tagAllModules(sharedtest.TestAuthor))
 			for _, tagName := range tc.shouldExistTags {
 				tagRef, tagRefErr := repo.Tag(tagName)


### PR DESCRIPTION
Resolves issue #205
## Summary

  Makes `multimod tag` idempotent by allowing it to run multiple times on the
  same commit without failing. When tags already exist on the specified commit,
  tag creation is skipped instead of returning an error. you can
  run `multimod tag` again to verify the tag list without it falling over.

  If tags exist on a *different* commit, the command still errors out to prevent
  accidental reuse.

  ## Changes

  - Added `alreadyTagged` field to the `tagger` struct to track whether tags
    already exist on the specified commit.
  - Updated `newTagger`: when tags already exist, verifies they are on the
    specified commit instead of failing immediately.
  - Updated `Run`: skips `tagAllModules` when already tagged.
  - Updated tests to cover the already-tagged-on-same-commit scenario.

  ## Testing
All tests pass