### PR TITLE
[githubgen]: add support for enforce team membership

### DIFF
--- a/.chloggen/githubgen-check-team-membership.yaml
+++ b/.chloggen/githubgen-check-team-membership.yaml
@@ -8,7 +8,7 @@ component: githubgen
 note: Add a `--github-team` flag to require codeowners to be members of a specific org team
 
 # One or more tracking issues related to the change
-issues: []
+issues: [1993]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/.chloggen/githubgen-check-team-membership.yaml
+++ b/.chloggen/githubgen-check-team-membership.yaml
@@ -1,0 +1,20 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. crosslink)
+component: githubgen
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add a `--github-team` flag to require codeowners to be members of a specific org team
+
+# One or more tracking issues related to the change
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  When `--github-team` is set, codeowners must be members of the given org team in addition to
+  being members of the organization. Team membership is what grants the repository access required
+  for a code owner to be requested as a reviewer. Allowlisted codeowners and org team handles are
+  exempt. When the flag is unset, behavior is unchanged and only organization membership is checked.

--- a/githubgen/README.md
+++ b/githubgen/README.md
@@ -44,10 +44,10 @@ OpenTelemetry organization, the script will error out.
 ## Checking codeowners against a team
 
 Optionally, you can require codeowners to be members of a specific org team in
-addition to being members of the organization by passing `--github-team
-<team-slug>`. Team membership is what grants the repository access required for
-a code owner to be requested as a reviewer, so an org member who is not on the
-team cannot be auto-requested for reviews.
+addition to being members of the organization by passing
+`--github-team <team-slug>`. Team membership is what grants the repository
+access required for a code owner to be requested as a reviewer, so an org member
+who is not on the team cannot be auto-requested for reviews.
 
 When `--github-team` is set, each codeowner (other than allowlisted users and
 org team handles) must be a member of that team. Codeowners in `allowlist.txt`

--- a/githubgen/README.md
+++ b/githubgen/README.md
@@ -40,3 +40,17 @@ These can be added to allowlist.txt as a workaround.
 
 If a codeowner is present in `allowlist.txt` and also a member of the
 OpenTelemetry organization, the script will error out.
+
+## Checking codeowners against a team
+
+Optionally, you can require codeowners to be members of a specific org team in
+addition to being members of the organization by passing `--github-team
+<team-slug>`. Team membership is what grants the repository access required for
+a code owner to be requested as a reviewer, so an org member who is not on the
+team cannot be auto-requested for reviews.
+
+When `--github-team` is set, each codeowner (other than allowlisted users and
+org team handles) must be a member of that team. Codeowners in `allowlist.txt`
+are exempt, since they are intentionally not organization members and therefore
+cannot be team members. If `--github-team` is not set, only organization
+membership is checked.

--- a/githubgen/codeowners.go
+++ b/githubgen/codeowners.go
@@ -19,10 +19,11 @@ import (
 )
 
 type codeownersGenerator struct {
-	skipGithub       bool
-	getGitHubMembers func(skipGithub bool, githubOrg string) (map[string]struct{}, error)
-	getFile          func(fileName string) ([]byte, error)
-	setFile          func(fileName string, data []byte) error
+	skipGithub           bool
+	getGitHubMembers     func(skipGithub bool, githubOrg string) (map[string]struct{}, error)
+	getGitHubTeamMembers func(skipGithub bool, githubOrg, teamSlug string) (map[string]struct{}, error)
+	getFile              func(fileName string) ([]byte, error)
+	setFile              func(fileName string, data []byte) error
 }
 
 func (cg *codeownersGenerator) Generate(data datatype.GithubData) error {
@@ -125,8 +126,12 @@ func (cg *codeownersGenerator) longestNameSpaces(data datatype.GithubData) int {
 //
 // If a codeOwner is not part of the GitHub org, that user will be looked for in the allowlist.
 //
+// When data.GitHubTeam is set, codeOwners must additionally be members of that
+// org team. Allowlisted code owners are exempt.
+//
 // The method returns an error if:
 // - there are code owners that are not org members and not in the allowlist (only if skipGithub is set to false)
+// - there are code owners that are not members of the required team and not in the allowlist (only if a team is configured and skipGithub is set to false)
 // - there are redundant entries in the allowlist
 // - there are entries in the allowlist that are unused
 func (cg *codeownersGenerator) verifyCodeOwnerOrgMembership(allowlistData []byte, data datatype.GithubData) error {
@@ -137,11 +142,20 @@ func (cg *codeownersGenerator) verifyCodeOwnerOrgMembership(allowlistData []byte
 	unusedAllowlist := append([]string{}, allowlist...)
 
 	var missingCodeowners []string
+	var missingTeamMembers []string
 	var duplicateCodeowners []string
 
 	members, err := cg.getGitHubMembers(cg.skipGithub, data.GitHubOrg)
 	if err != nil {
 		return err
+	}
+
+	var teamMembers map[string]struct{}
+	if data.GitHubTeam != "" {
+		teamMembers, err = cg.getGitHubTeamMembers(cg.skipGithub, data.GitHubOrg, data.GitHubTeam)
+		if err != nil {
+			return err
+		}
 	}
 
 	// sort codeowners
@@ -161,6 +175,10 @@ func (cg *codeownersGenerator) verifyCodeOwnerOrgMembership(allowlistData []byte
 			}
 		} else if slices.Contains(allowlist, codeowner) {
 			duplicateCodeowners = append(duplicateCodeowners, codeowner)
+		} else if data.GitHubTeam != "" {
+			if _, ownerPresentInTeam := teamMembers[codeowner]; !ownerPresentInTeam {
+				missingTeamMembers = append(missingTeamMembers, codeowner)
+			}
 		}
 	}
 
@@ -168,6 +186,10 @@ func (cg *codeownersGenerator) verifyCodeOwnerOrgMembership(allowlistData []byte
 	if len(missingCodeowners) > 0 && !cg.skipGithub {
 		sort.Strings(missingCodeowners)
 		return fmt.Errorf("codeowners are not members: %s", strings.Join(missingCodeowners, ", "))
+	}
+	if len(missingTeamMembers) > 0 && !cg.skipGithub {
+		sort.Strings(missingTeamMembers)
+		return fmt.Errorf("codeowners are not members of the %s/%s team: %s", data.GitHubOrg, data.GitHubTeam, strings.Join(missingTeamMembers, ", "))
 	}
 	if len(duplicateCodeowners) > 0 {
 		sort.Strings(duplicateCodeowners)
@@ -207,6 +229,42 @@ func getGithubMembers(skipGithub bool, githubOrg string) (map[string]struct{}, e
 		}
 		allUsers = append(allUsers, users...)
 		pageIndex++
+	}
+
+	usernames := make(map[string]struct{}, len(allUsers))
+	for _, u := range allUsers {
+		usernames[*u.Login] = struct{}{}
+	}
+	return usernames, nil
+}
+
+func getGithubTeamMembers(skipGithub bool, githubOrg, teamSlug string) (map[string]struct{}, error) {
+	if skipGithub || teamSlug == "" {
+		// don't try to get team members if no token is expected or no team is configured
+		return map[string]struct{}{}, nil
+	}
+	githubToken := os.Getenv("GITHUB_TOKEN")
+	if githubToken == "" {
+		return nil, fmt.Errorf("set the environment variable `GITHUB_TOKEN` to a PAT token to authenticate")
+	}
+	client := github.NewClient(nil).WithAuthToken(githubToken)
+	var allUsers []*github.User
+	opts := &github.TeamListTeamMembersOptions{
+		ListOptions: github.ListOptions{
+			PerPage: 50,
+		},
+	}
+	for {
+		users, resp, err := client.Teams.ListTeamMembersBySlug(context.Background(), githubOrg, teamSlug, opts)
+		if err != nil {
+			return nil, err
+		}
+		defer resp.Body.Close()
+		allUsers = append(allUsers, users...)
+		if resp.NextPage == 0 {
+			break
+		}
+		opts.Page = resp.NextPage
 	}
 
 	usernames := make(map[string]struct{}, len(allUsers))

--- a/githubgen/codeowners.go
+++ b/githubgen/codeowners.go
@@ -162,7 +162,8 @@ func (cg *codeownersGenerator) verifyCodeOwnerOrgMembership(allowlistData []byte
 	for _, codeowner := range data.Codeowners {
 		_, ownerPresentInMembers := members[codeowner]
 
-		if !ownerPresentInMembers {
+		switch {
+		case !ownerPresentInMembers:
 			ownerInAllowlist := slices.Contains(allowlist, codeowner)
 			unusedAllowlist = slices.DeleteFunc(unusedAllowlist, func(s string) bool {
 				return s == codeowner
@@ -173,9 +174,9 @@ func (cg *codeownersGenerator) verifyCodeOwnerOrgMembership(allowlistData []byte
 			if !ownerInAllowlist {
 				missingCodeowners = append(missingCodeowners, codeowner)
 			}
-		} else if slices.Contains(allowlist, codeowner) {
+		case slices.Contains(allowlist, codeowner):
 			duplicateCodeowners = append(duplicateCodeowners, codeowner)
-		} else if data.GitHubTeam != "" {
+		case data.GitHubTeam != "":
 			if _, ownerPresentInTeam := teamMembers[codeowner]; !ownerPresentInTeam {
 				missingTeamMembers = append(missingTeamMembers, codeowner)
 			}

--- a/githubgen/codeowners_test.go
+++ b/githubgen/codeowners_test.go
@@ -160,6 +160,17 @@ func Test_codeownersGenerator_verifyCodeOwnerTeamMembership(t *testing.T) {
 			},
 			wantErr: false,
 		},
+		{
+			name:      "org member on the allowlist reports a duplicate, not a missing team member",
+			allowlist: []byte("user3"),
+			data: datatype.GithubData{
+				GitHubOrg:  "open-telemetry",
+				GitHubTeam: "some-team",
+				Codeowners: []string{"user3"},
+			},
+			wantErr:     true,
+			errContains: "codeowners members duplicate in allowlist: user3",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/githubgen/codeowners_test.go
+++ b/githubgen/codeowners_test.go
@@ -192,6 +192,48 @@ func Test_codeownersGenerator_verifyCodeOwnerTeamMembership(t *testing.T) {
 	}
 }
 
+func Test_getGithubTeamMembers(t *testing.T) {
+	tests := []struct {
+		name       string
+		skipGithub bool
+		org        string
+		team       string
+		token      string
+		wantErr    bool
+	}{
+		{
+			name:       "skipGithub returns an empty set without calling GitHub",
+			skipGithub: true,
+			org:        "open-telemetry",
+			team:       "some-team",
+		},
+		{
+			name: "empty team returns an empty set without calling GitHub",
+			org:  "open-telemetry",
+			team: "",
+		},
+		{
+			name:    "missing token errors",
+			org:     "open-telemetry",
+			team:    "some-team",
+			token:   "",
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("GITHUB_TOKEN", tt.token)
+			got, err := getGithubTeamMembers(tt.skipGithub, tt.org, tt.team)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Empty(t, got)
+		})
+	}
+}
+
 func Test_codeownersGenerator_longestNameSpaces(t *testing.T) {
 	longName := "name-looooong"
 	type args struct {

--- a/githubgen/codeowners_test.go
+++ b/githubgen/codeowners_test.go
@@ -95,6 +95,92 @@ func Test_codeownersGenerator_verifyCodeOwnerOrgMembership(t *testing.T) {
 	}
 }
 
+func Test_codeownersGenerator_verifyCodeOwnerTeamMembership(t *testing.T) {
+	tests := []struct {
+		name        string
+		skipGithub  bool
+		allowlist   []byte
+		data        datatype.GithubData
+		wantErr     bool
+		errContains string
+	}{
+		{
+			name: "all codeowners are team members",
+			data: datatype.GithubData{
+				GitHubOrg:  "open-telemetry",
+				GitHubTeam: "some-team",
+				Codeowners: []string{"user1", "user2"},
+			},
+			wantErr: false,
+		},
+		{
+			name: "codeowner is an org member but not a team member",
+			data: datatype.GithubData{
+				GitHubOrg:  "open-telemetry",
+				GitHubTeam: "some-team",
+				Codeowners: []string{"user1", "user3"},
+			},
+			wantErr:     true,
+			errContains: "codeowners are not members of the open-telemetry/some-team team: user3",
+		},
+		{
+			name:      "non-org-member on the allowlist is exempt from the team check",
+			allowlist: []byte("user4"),
+			data: datatype.GithubData{
+				GitHubOrg:  "open-telemetry",
+				GitHubTeam: "some-team",
+				Codeowners: []string{"user1", "user4"},
+			},
+			wantErr: false,
+		},
+		{
+			name: "org team handle is exempt from the team check",
+			data: datatype.GithubData{
+				GitHubOrg:  "open-telemetry",
+				GitHubTeam: "some-team",
+				Codeowners: []string{"user1", "open-telemetry/some-other-team"},
+			},
+			wantErr: false,
+		},
+		{
+			name:       "team check is skipped when skipGithub is set",
+			skipGithub: true,
+			data: datatype.GithubData{
+				GitHubOrg:  "open-telemetry",
+				GitHubTeam: "some-team",
+				Codeowners: []string{"user1", "user3"},
+			},
+			wantErr: false,
+		},
+		{
+			name: "no team configured preserves org-only behavior",
+			data: datatype.GithubData{
+				GitHubOrg:  "open-telemetry",
+				Codeowners: []string{"user1", "user3"},
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cg := &codeownersGenerator{
+				skipGithub:           tt.skipGithub,
+				getGitHubMembers:     mockGithubMembers,
+				getGitHubTeamMembers: mockGithubTeamMembers,
+			}
+			err := cg.verifyCodeOwnerOrgMembership(tt.allowlist, tt.data)
+			if tt.wantErr {
+				require.Error(t, err)
+				if tt.errContains != "" {
+					require.Contains(t, err.Error(), tt.errContains)
+				}
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
 func Test_codeownersGenerator_longestNameSpaces(t *testing.T) {
 	longName := "name-looooong"
 	type args struct {
@@ -419,6 +505,15 @@ func mockGithubMembers(bool, string) (map[string]struct{}, error) {
 		"user1": {},
 		"user2": {},
 		"user3": {},
+	}, nil
+}
+
+// mockGithubTeamMembers returns a subset of mockGithubMembers: user3 is an org
+// member but not a team member.
+func mockGithubTeamMembers(bool, string, string) (map[string]struct{}, error) {
+	return map[string]struct{}{
+		"user1": {},
+		"user2": {},
 	}, nil
 }
 

--- a/githubgen/datatype/data.go
+++ b/githubgen/datatype/data.go
@@ -22,6 +22,7 @@ type GithubData struct {
 	Distributions     []DistributionData
 	DefaultCodeOwner  string
 	GitHubOrg         string
+	GitHubTeam        string
 	Chloggen          ChloggenConfig
 }
 

--- a/githubgen/main.go
+++ b/githubgen/main.go
@@ -29,6 +29,7 @@ func main() {
 	defaultCodeOwner := flag.String("default-codeowner", "@open-telemetry/collector-contrib-approvers", "GitHub user or team name that will be used as default codeowner")
 	trimSuffixes := flag.String("trim-component-suffixes", "receiver, exporter, extension, processor, connector, internal", "Define a comma-separated list of suffixes that should be trimmed from paths during generation of issue templates")
 	githubOrgSlug := flag.String("github-org", "open-telemetry", "GitHub organization name to check if codeowners are org members")
+	githubTeamSlug := flag.String("github-team", "", "if set, the org team slug that codeowners must be members of (in addition to being org members)")
 
 	flag.Parse()
 
@@ -42,7 +43,7 @@ func main() {
 		log.Fatal(err)
 	}
 
-	if err = run(*folder, *allowlistFilePath, generators, distributions, *defaultCodeOwner, *githubOrgSlug); err != nil {
+	if err = run(*folder, *allowlistFilePath, generators, distributions, *defaultCodeOwner, *githubOrgSlug, *githubTeamSlug); err != nil {
 		log.Fatal(err)
 	}
 }
@@ -93,7 +94,7 @@ func loadMetadata(filePath string) (datatype.Metadata, error) {
 	return md, nil
 }
 
-func run(folder string, allowlistFilePath string, generators []datatype.Generator, distros []datatype.DistributionData, defaultCodeOwner string, githubOrg string) error {
+func run(folder string, allowlistFilePath string, generators []datatype.Generator, distros []datatype.DistributionData, defaultCodeOwner string, githubOrg string, githubTeam string) error {
 	components := map[string]datatype.Metadata{}
 	var foldersList []string
 	maxLength := 0
@@ -168,6 +169,7 @@ func run(folder string, allowlistFilePath string, generators []datatype.Generato
 		Distributions:     distros,
 		DefaultCodeOwner:  defaultCodeOwner,
 		GitHubOrg:         githubOrg,
+		GitHubTeam:        githubTeam,
 		Chloggen:          chloggenCfg,
 	}
 
@@ -200,7 +202,7 @@ func newIssueTemplatesGenerator(trimSuffixes string) *issueTemplatesGenerator {
 }
 
 func newCodeownersGenerator(skipGithubCheck *bool) *codeownersGenerator {
-	return &codeownersGenerator{skipGithub: *skipGithubCheck, getGitHubMembers: getGithubMembers, getFile: getFile, setFile: setFile}
+	return &codeownersGenerator{skipGithub: *skipGithubCheck, getGitHubMembers: getGithubMembers, getGitHubTeamMembers: getGithubTeamMembers, getFile: getFile, setFile: setFile}
 }
 
 func newDistributionsGenerator() *distributionsGenerator {

--- a/githubgen/main_test.go
+++ b/githubgen/main_test.go
@@ -22,6 +22,7 @@ func Test_run(t *testing.T) {
 		distributions     []datatype.DistributionData
 		defaultCodeOwners string
 		githubOrg         string
+		githubTeam        string
 	}
 	tests := []struct {
 		name    string
@@ -77,7 +78,7 @@ func Test_run(t *testing.T) {
 	// nolint:govet
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if err := run(tt.args.folder, tt.args.allowlistFilePath, []datatype.Generator{&tt.args.generators}, tt.args.distributions, tt.args.defaultCodeOwners, tt.args.githubOrg); (err != nil) != tt.wantErr {
+			if err := run(tt.args.folder, tt.args.allowlistFilePath, []datatype.Generator{&tt.args.generators}, tt.args.distributions, tt.args.defaultCodeOwners, tt.args.githubOrg, tt.args.githubTeam); (err != nil) != tt.wantErr {
 				t.Errorf("run() error = %v, wantErr %v", err, tt.wantErr)
 			}
 			require.Equal(t, len(tt.args.generators.GenerateCalls()), 1)


### PR DESCRIPTION
This PR adds a new feature to githubgen to allow additionally enforcing that code owners are a member of a specific team within an org. This is necessary for repos like Collector Contrib that use https://github.com/orgs/open-telemetry/teams/collector-contrib-contributors to give code owners the rights needed to be requested as reviewers on PRs.