### PR TITLE
Feature: Adding support for telemetry changelog type

### DIFF
--- a/chloggen/internal/chlog/entry.go
+++ b/chloggen/internal/chlog/entry.go
@@ -40,6 +40,8 @@ const (
 	Enhancement = "enhancement"
 	// BugFix is a bug fix change.
 	BugFix = "bug_fix"
+	// Telemetry is for changes in signals.
+	Telemetry = "telemetry"
 )
 
 // Entry represents a changelog entry.
@@ -58,6 +60,7 @@ var changeTypes = []string{
 	NewComponent,
 	Enhancement,
 	BugFix,
+	Telemetry,
 }
 
 // Validate validates the changelog entry.

--- a/chloggen/internal/chlog/entry_test.go
+++ b/chloggen/internal/chlog/entry_test.go
@@ -48,7 +48,7 @@ func TestEntry(t *testing.T) {
 		{
 			name:      "empty",
 			entry:     Entry{},
-			expectErr: "'' is not a valid 'change_type'. Specify one of [breaking deprecation new_component enhancement bug_fix]\nspecify a 'component'\nspecify a 'note'\nspecify one or more issues #'s",
+			expectErr: "'' is not a valid 'change_type'. Specify one of [breaking deprecation new_component enhancement bug_fix telemetry]\nspecify a 'component'\nspecify a 'note'\nspecify one or more issues #'s",
 		},
 		{
 			name: "missing_component",


### PR DESCRIPTION
# Context

This adds in support for a new changelog type that would allow for users to define telemetry changes that will appear in the changelog. 

# Issue

https://github.com/open-telemetry/opentelemetry-go-build-tools/issues/2016

# Tests

Updated where impacted.