### PR TITLE
Feature: Adding support for telemetry changelog type

### DIFF
--- a/.chloggen/TEMPLATE.yaml
+++ b/.chloggen/TEMPLATE.yaml
@@ -1,4 +1,4 @@
-# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix', 'telemetry'
 change_type:
 
 # The name of the component, or a single word describing the area of concern, (e.g. crosslink)

--- a/.chloggen/msg_chloggen-add-telemetry-change.yaml
+++ b/.chloggen/msg_chloggen-add-telemetry-change.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. crosslink)
+component: chloggen
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: This adds a new change type of `telemetry`
+
+# One or more tracking issues related to the change
+issues: [2016]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/chloggen/internal/chlog/TEMPLATE.yaml
+++ b/chloggen/internal/chlog/TEMPLATE.yaml
@@ -7,7 +7,7 @@
 # Default: '[user]'
 change_logs: []
 
-# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix', 'telemetry'
 change_type:
 
 # The name of the component, or a single word describing the area of concern, (e.g. crosslink)

--- a/chloggen/internal/chlog/entry.go
+++ b/chloggen/internal/chlog/entry.go
@@ -40,6 +40,8 @@ const (
 	Enhancement = "enhancement"
 	// BugFix is a bug fix change.
 	BugFix = "bug_fix"
+	// Telemetry is for changes in signals.
+	Telemetry = "telemetry"
 )
 
 // Entry represents a changelog entry.
@@ -58,6 +60,7 @@ var changeTypes = []string{
 	NewComponent,
 	Enhancement,
 	BugFix,
+	Telemetry,
 }
 
 // Validate validates the changelog entry.

--- a/chloggen/internal/chlog/entry_test.go
+++ b/chloggen/internal/chlog/entry_test.go
@@ -48,7 +48,7 @@ func TestEntry(t *testing.T) {
 		{
 			name:      "empty",
 			entry:     Entry{},
-			expectErr: "'' is not a valid 'change_type'. Specify one of [breaking deprecation new_component enhancement bug_fix]\nspecify a 'component'\nspecify a 'note'\nspecify one or more issues #'s",
+			expectErr: "'' is not a valid 'change_type'. Specify one of [breaking deprecation new_component enhancement bug_fix telemetry]\nspecify a 'component'\nspecify a 'note'\nspecify one or more issues #'s",
 		},
 		{
 			name: "missing_component",


### PR DESCRIPTION
# Context

This adds in support for a new changelog type that would allow for users to define telemetry changes that will appear in the changelog. 

# Issue

https://github.com/open-telemetry/opentelemetry-go-build-tools/issues/2016

# Tests

Updated where impacted.